### PR TITLE
Careful schema for experiments; addReport method

### DIFF
--- a/TummyTrials/www/js/app.js
+++ b/TummyTrials/www/js/app.js
@@ -51,16 +51,20 @@ app.run(function($ionicPlatform, $rootScope, $q, Text, Experiments, Login,
     // Try some tests. Move these into some kind of framework later on,
     // probably.
     //
-    //ExperTest.testAll()
-    //.then(ExperTest.testGet)
-    //.then(ExperTest.testGetCurrent)
-    //.then(ExperTest.testAdd)
-    //.then(ExperTest.testSetStatus)
-    //.then(ExperTest.testDelete)
-    //.then(
-    //    function good() {},
-    //    function bad(err) { console.log('error ' + err.message); }
-    //);
+    var want_to_run_these_tests = false;
+    if (want_to_run_these_tests) {
+        ExperTest.testAll()
+        .then(ExperTest.testGet)
+        .then(ExperTest.testGetCurrent)
+        .then(ExperTest.testAdd)
+        .then(ExperTest.testSetStatus)
+        .then(ExperTest.testAddReport)
+        .then(ExperTest.testDelete)
+        .then(
+            function good() {},
+            function bad(err) { console.log('error ' + err.message); }
+        );
+    }
   });
 })
 


### PR DESCRIPTION
Two-level typing (document and data), plus version numbers. This is what we decided on a while back (or pretty close).

Also implemented addReport, a way to add a report to an experiment (assuming an array of reports will be kept inside experiment documents).

Updated the unit tests to work with new schema and to test addReport.

The code is currently completely agnostic about what a report looks like.