### PR TITLE
Reminders API manages reminders and badge

### DIFF
--- a/TummyTrials/config.xml
+++ b/TummyTrials/config.xml
@@ -18,6 +18,8 @@
   <preference name="SplashScreenDelay" value="3000"/>
 
   <plugin name="com.couchbase.lite.phonegap" />
+  <plugin name="de.appplant.cordova.plugin.local-notification" />
+  <plugin name="de.appplant.cordova.plugin.badge" />
 
   <feature name="StatusBar">
     <param name="ios-package" value="CDVStatusBar" onload="true"/>

--- a/TummyTrials/www/index.html
+++ b/TummyTrials/www/index.html
@@ -23,6 +23,7 @@
     <!-- your app's js -->
     <script src="js/app.js"></script>
     <script src="js/controllers/experiments.js"></script>
+    <script src="js/controllers/reminders.js"></script>
     <script src="js/controllers/login.js"></script>
     <script src="js/controllers/text.js"></script>
     <script src="js/controllers/mytrialsctrl.js"></script>
@@ -34,6 +35,7 @@
     <script src="js/controllers/ngcordovacontrollers.js"></script>
     <!-- Some tests -->
     <script src="js/controllers/exper-test.js"></script>
+    <script src="js/controllers/remind-test.js"></script>
 
     <ion-nav-bar class="bar-royal nav-title-slide-ios7">
       <ion-nav-back-button class="button-clear">

--- a/TummyTrials/www/js/app.js
+++ b/TummyTrials/www/js/app.js
@@ -24,11 +24,11 @@ angular.module('starter', ['ionic'])
 'use strict';
 
 var app = angular.module('tummytrials',
-            ['ionic', 'ngSanitize', 'tummytrials.login', 'tummytrials.currentstudy', 'tummytrials.studysetup', 'tummytrials.faqcontroller', 'ngCordova', 'tummytrials.mytrialsctrl', 'tummytrials.ngcordovacontrollers', 'tummytrials.text', 'tummytrials.experiments', 'tummytrials.exper-test']);
+            ['ionic','ngSanitize','tummytrials.login','tummytrials.currentstudy','tummytrials.studysetup','tummytrials.faqcontroller', 'ngCordova','tummytrials.mytrialsctrl', 'tummytrials.ngcordovacontrollers', 'tummytrials.text', 'tummytrials.experiments', 'tummytrials.exper-test', 'tractdb.reminders', 'tummytrials.remind-test']);
 
 //Ionic device ready check
-app.run(function($ionicPlatform, $rootScope, $q, Text, Experiments, Login,
-                    ExperTest) {
+app.run(function($ionicPlatform, $rootScope, $q, Login, Text, Experiments,
+                    Reminders, ExperTest, RemindTest) {
 
   $ionicPlatform.ready(function() {
     // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
@@ -48,11 +48,11 @@ app.run(function($ionicPlatform, $rootScope, $q, Text, Experiments, Login,
                                 Experiments.valid_p);
     });
 
-    // Try some tests. Move these into some kind of framework later on,
-    // probably.
+    // Some tests of Experiments. Move these into some kind of framework
+    // later on, probably.
     //
-    var want_to_run_these_tests = false;
-    if (want_to_run_these_tests) {
+    var want_to_run_exper_tests = false;
+    if (want_to_run_exper_tests) {
         ExperTest.testAll()
         .then(ExperTest.testGet)
         .then(ExperTest.testGetCurrent)
@@ -62,10 +62,28 @@ app.run(function($ionicPlatform, $rootScope, $q, Text, Experiments, Login,
         .then(ExperTest.testDelete)
         .then(
             function good() {},
-            function bad(err) { console.log('error ' + err.message); }
+            function bad(err) {
+                console.log('ExperTest error ' + err.message);
+            }
         );
     }
+
+    // Some tests of Reminders. Right now these require human
+    // intervention and observation.
+    //
+    var want_to_run_remind_tests = false;
+    if (want_to_run_remind_tests) {
+        RemindTest.testSync()
+        .then(
+            function good() {},
+            function bad(err) {
+                console.log('RemindTest error ' + err.message);
+            }
+        );
+    }
+
   });
+
 })
 
 

--- a/TummyTrials/www/js/controllers/remind-test.js
+++ b/TummyTrials/www/js/controllers/remind-test.js
@@ -1,0 +1,275 @@
+// remind-test.js     Some tests of the reminders module
+//
+// It's exceptionally tricky to test the reminder module because much of
+// the behavior to be tested happens when the app is *not* active. Hence
+// you can't run code to see if things worked right.
+//
+// We currently depend on cooperation of the user, and we run different
+// parts of the test at separate startup times.
+//
+// To run the tests, currently need to start the app in the Xcode
+// debugger three times. The third time is just for cleanup.
+//
+
+'use strict';
+
+(angular.module('tummytrials.remind-test', [ 'tractdb.reminders' ])
+
+.factory('RemindTest', function(Reminders) {
+    var sync_duration = 3; // Days in fake study
+
+    var descs = [
+        { type: 'testSyncA',
+          time: 0, // Fix up in test_sync_0
+          heads: ['First Reminder'],
+          bodies: ['Badge goes to 1']
+        },
+        { type: 'testSyncB',
+          reminderonly: true,
+          time: 0, // Fix up in test_sync_1
+          heads: ['Second Reminder', 'Tomorrow Head'],
+          bodies: ['Badge stays at 1', 'Tomorrow Body']
+        },
+        { type: 'testSyncC',
+          time: 0, // Fix up in test_sync_1
+          heads: ['Third Reminder'],
+          bodies: ['Badge goes to 2']
+        }
+    ];
+
+    function by_at(a, b)
+    {
+        if (a.at < b.at) return -1;
+        if (a.at > b.at) return 1;
+        return 0;
+    }
+
+    function study_start_time()
+    {
+        // The study start time for the tests is midnight at the
+        // beginning of today. (Don't run the tests just before
+        // midnight.)
+        //
+        var d = new Date(); // Now
+        var m = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+        return Math.trunc(m.getTime() / 1000); // Epoch time
+    }
+
+    function study_end_time(duration)
+    {
+        // The study end time for the tests is midnight at the beginning
+        // of duration days from now. (Don't run the tests just before
+        // daylight savings switchover.)
+        //
+        return study_start_time() + duration * 24 * 60 * 60;
+    }
+
+
+    function at_time(start_time, n, time)
+    {
+        var s = new Date(start_time * 1000);
+        var a = new Date(s.getFullYear(), s.getMonth(), s.getDate() + n - 1,
+                         Math.trunc(time / 3600),
+                         Math.trunc((time % 3600) / 60),
+                         Math.trunc(time % 60));
+        return Math.trunc(a.getTime() / 1000);
+    }
+
+
+    function test_remind(descr, start_time, n, state)
+    {
+        // Return a notification object for the given reminder
+        // descriptor and other state. The return value looks like what
+        // Reminders.list() returns.
+        //
+        function nthstr(a) {
+            if (n > a.length) return a[a.length-1]; else return a[n-1];
+        }
+        var remind = {};
+        remind.badge = 0; // Caller should fix up later
+        remind.data = descr.type;
+        remind.id = 0; // Caller should fix up later
+        remind.title = nthstr(descr.heads);
+        remind.text = nthstr(descr.bodies);
+        if (!descr.reminderonly) remind.every = 'day';
+        remind.at = at_time(start_time, n, descr.time);
+        remind.sound = 'res://platform_default';
+        remind.state = state;
+        return remind;
+    }
+
+    function validate_reminds_equal(as, bs, tag)
+    {
+        if (!angular.equals(as, bs)) {
+            console.log('validate_reminds_equal<' + tag + '>: failure');
+            throw new Error('validate_reminds_equal<' + tag + '>');
+        }
+        console.log('validate_reminds_equal<' + tag + '>: success');
+    }
+
+    function expected_round_1()
+    {
+        var start = study_start_time();
+        var expected = [];
+        for (var i = 0; i < descs.length; i++) {
+            var reps = descs[i].reminderonly ? sync_duration : 1;
+            for (var j = 1; j <= reps; j++)
+                expected.push(test_remind(descs[i], start, j, 'scheduled'));
+        }
+        expected.sort(by_at);
+        var badge = 0;
+        expected.forEach(function(notif, ix) {
+            notif.id = ix + 1;
+            if (notif.every) badge++;
+            notif.badge = badge;
+        });
+        return expected;
+    }
+
+    function test_sync_1(notifs0)
+    {
+        var d = new Date(); // Now
+        var nowsec =
+            d.getHours() * 3600 + d.getMinutes() * 60 + d.getSeconds();
+        descs[0].time = nowsec + 30; // 30 seconds from now
+        descs[1].time = nowsec + 50; // 20 seconds after that
+        descs[2].time = nowsec + 70; // 20 seconds after that
+
+        return Reminders.clear()
+        .then(function(_) {
+            return Reminders.sync(descs, study_start_time(),
+                                    study_end_time(sync_duration), []);
+        })
+        .then(function(_) {
+            return Reminders.list();
+        })
+        .then(function(notifs) {
+            var expected = expected_round_1();
+            validate_reminds_equal(notifs, expected, 'testSync 1');
+            console.log('Please exit to home screen (touch home button)');
+            console.log('You should see three notifications');
+            console.log('Badge should go to 1 -- 1 -- 2');
+            console.log('Notification center should contain all 3');
+        })
+    }
+
+    function test_sync_2(notifs0)
+    {
+        var start = study_start_time();
+        var end = study_end_time(sync_duration);
+        var nowepoch = Math.trunc(Date.now() / 1000);
+
+        // Use time of first notification as a base for the expected
+        // times of the rest.
+        //
+        if (notifs0.length < 1)
+            throw new Error("testSync 2 A (no notifications)");
+        if (notifs0[0].at < nowepoch - 600)
+            console.log('testSync 2 notifications suspiciously old');
+        var time0 = notifs0[0].at - start;
+
+        // Reestablish the times used in test_sync_1;
+        //
+        descs[0].time = time0;
+        descs[1].time = time0 + 20;
+        descs[2].time = time0 + 40;
+
+        // Verify that we see what we expect. The only difference is
+        // that the first three have now been triggered.
+        //
+        var expected = expected_round_1();
+        for (var i = 0; i < 3; i++)
+            expected[i].state = 'triggered';
+        validate_reminds_equal(notifs0, expected, 'testSync 2 before');
+
+        // Make all reports that are due, then check again.
+        //
+        var reps = [];
+
+        descs.forEach(function(desc) {
+            if (!desc.reminderonly)
+                reps.push({ type: desc.type });
+        });
+
+        return Reminders.sync(descs, start, end, reps)
+        .then(function(_) { return Reminders.list(); })
+        .then(function(notifs) {
+            var expected = [];
+            notifs0.forEach(function(notif) {
+                if (notif.state == 'triggered' && !notif.every) {
+                    // This notification will be left in the
+                    // Notification Center. So we expect to see it in
+                    // the list.
+                    //
+                    expected.push(notif);
+                }
+            });
+            for (var i = 0; i < descs.length; i++) {
+                var reps = descs[i].reminderonly ? sync_duration : 2;
+                for (var j = 2; j <= reps; j++)
+                    expected.push(test_remind(descs[i], start, j,
+                                    'scheduled'));
+            }
+            expected.sort(by_at);
+            var badge = 0;
+            var nextid = notifs.length + 1;
+            expected.forEach(function(notif) {
+                if(notif.id == 0) {
+                    notif.id = nextid++;
+                    if (notif.every) badge++;
+                    notif.badge = badge;
+                }
+            });
+            validate_reminds_equal(notifs, expected, 'testSync 2 after');
+            console.log('Please exit to home screen (touch home button)');
+            console.log('Badge should have disappeared');
+            console.log('Notification center should have Second Reminder');
+            console.log('(But it doesn\'t)');
+        });
+    }
+
+    function test_sync_cleanup(notifs0)
+    {
+        return Reminders.clear()
+        .then(function(_) {
+            console.log('Test notifications have been cleared');
+        });
+    }
+
+    return {
+        testSync: function() {
+            // Return a promise to perform one of three tests. If there
+            // are no test notifications, set up some notifications and
+            // ask user to see if they get delivered as expected. If
+            // there is a test notification for a report that's due,
+            // simulate the report. Then ask user to see whether the
+            // badge has changed. If there are notifications, but none
+            // for an undelivered report, clean up by removing all the
+            // notifications.
+            //
+            return Reminders.list()
+            .then(function(notifs) {
+                var testnotif = -1, testnotiftrig = -1;
+
+                for (var i = 0; i < notifs.length; i++)
+                    if (notifs[i].data.search(/^testSync/) >= 0) {
+                        if (testnotif < 0)
+                            testnotif = i;
+                        if (notifs[i].state == 'triggered' &&
+                            notifs[i].every &&
+                            testnotiftrig < 0) {
+                            testnotiftrig = i;
+                            break;
+                        }
+                    }
+                    if (testnotif < 0)
+                        return test_sync_1(notifs);
+                    if (testnotiftrig >= 0)
+                        return test_sync_2(notifs);
+                    return test_sync_cleanup(notifs);
+            })
+        }
+    };
+})
+
+)

--- a/TummyTrials/www/js/controllers/reminders.js
+++ b/TummyTrials/www/js/controllers/reminders.js
@@ -1,0 +1,344 @@
+// reminders.js     Schedule reminders and keep icon badge up to date
+//
+// Assumptions: there are some small number of reminders per day, of
+// different types. Some types are just "pure" reminders that display a
+// notification at a certain time. Other types are asking the user to
+// make a report, where the report is given the same type as the
+// reminder. Each type of reminder happens at a different time of day,
+// but at the same time every day.
+//
+// This code manages local notifications and the badge on the app icon.
+// As long as the user stays fairly current (no more than a day behind),
+// the badge shows the number of reports that are due, even when the app
+// isn't running. If the user falls far behind, the badge is still a
+// reliable indicator that at least one report is due.
+//
+// For things to work, you just have to call sync() any time there is
+// new information about reminders or reports. Examples of such times:
+//
+//     App startup (if there is a current study)
+//     User creates a study
+//     User submits a report
+//     User sets new reminder times
+//
+// You can call list() to get a list of current reminders, though this
+// is intended mostly for testing.
+//
+
+// TODO: handle the case where events are delivered while app is active
+
+'use strict';
+
+(angular.module('tractdb.reminders', [ 'ngCordova' ])
+
+.factory('Reminders', function($q, $cordovaLocalNotification, $cordovaBadge) {
+    var c_remstate; // Cached reminder state for internal use
+
+    function by_at(a, b)
+    {
+        if (a.at < b.at) return -1;
+        if (a.at > b.at) return 1;
+        return 0;
+    }
+
+    function sec_after_midnight()
+    {
+        // How many seconds after midnight is it right now?
+        //
+        var now = new Date();
+        return (now.getHours() * 60 + now.getMinutes()) * 60 + now.getSeconds();
+    }
+    
+    function study_day(remstate, date)
+    {
+        // Return the day of the study on the given date: 1, 2, 3, ... N
+        //
+        // Note that remstate.start_date is an Epoch time, 00:00:00 on
+        // the first day of the study.
+        //
+        var date0 =
+            new Date(date.getFullYear(), date.getMonth(), date.getDate());
+        var d0ep = Math.trunc(date0.getTime() / 1000);
+        return 1 + Math.round((d0ep - remstate.start_date) / 86400);
+    }
+
+    function study_day_today(remstate)
+    {
+        return study_day(remstate, new Date());
+    }
+
+    function reminder_time(start, n, time)
+    {
+        // Return a reminder time as a Date object.
+        //
+        // start: start of experiment (Epoch value, midnight of day 1)
+        // n:     day of study (1, ...)
+        // time:  time of reminder (seconds after midnight)
+        //
+        var startDate = new Date(start * 1000);
+        var h = Math.trunc(time / 3600);
+        var m = Math.trunc((time % 3600) / 60);
+        var s = Math.trunc(time % 60);
+        return new Date(startDate.getFullYear(), startDate.getMonth(),
+                        startDate.getDate() + n - 1, // Date will normalize
+                        h, m, s);
+    }
+
+    function notifications_now_p()
+    {
+        // Return a promise for the notifications that exist now. The
+        // promise resolves to an array of local notifications with a
+        // 'state' property that is either 'scheduled' or 'triggered'.
+        //
+        var res = [];
+
+        return $cordovaLocalNotification.getAllScheduled()
+        .then(function(notifs) {
+            notifs.forEach(function(notif) {
+                notif.state = 'scheduled';
+                res.push(notif);
+            });
+            return $cordovaLocalNotification.getAllTriggered();
+        })
+        .then(function(notifs) {
+            notifs.forEach(function(notif) {
+                notif.state = 'triggered';
+                res.push(notif);
+            });
+            return res;
+        })
+    }
+
+    function notifications_new(remstate, reports_for_type, app_badge, base_id)
+    {
+        // Return an array of notifications that follow from the given
+        // new status:
+        //
+        // remstate:          Reminder state
+        // reports_for_type:  Number of reports for each type
+        // app_badge:         App's correct badge count now
+        // base_id:           Base number for new notification ids
+        //
+        var sday = study_day_today(remstate);
+        var daysec = sec_after_midnight();
+
+        // Duration of study in days.
+        //
+        var duration = remstate.end_date - remstate.start_date;
+        duration = Math.round(duration / (60 * 60 * 24));
+
+        var notifs = [];
+        remstate.descs.forEach(function(desc) {
+            // Head for day n
+            function headn(n) {
+                return desc.heads[Math.min(n, desc.heads.length) - 1];
+            }
+            // Body for day n
+            function bodyn(n) {
+                return desc.bodies[Math.min(n, desc.bodies.length) - 1];
+            }
+            // Notification for day n
+            function notifn(n) {
+                var notif = {};
+                notif.title = headn(n);
+                notif.text = bodyn(n);
+                notif.at = reminder_time(remstate.start_date, n, desc.time);
+                notif.data = desc.type;
+                if (!desc.reminderonly)
+                    notif.every = 'day';
+                return notif;
+            }
+
+            // Day of next reminder of this type
+            var nnext = sday + (daysec > desc.time ? 1 : 0);
+
+            if (desc.reminderonly) {
+                // Separate notification for each. (Rationale: user has
+                // no reason to execute code in the app for these
+                // reminders, so we don't get chance to keep them
+                // current.)
+                //
+                for (var n = nnext; n <= duration; n++)
+                    notifs.push(notifn(n));
+            } else {
+                // Automatically rescheduled notification.
+                //
+                if (nnext <= duration)
+                    notifs.push(notifn(nnext));
+            }
+        });
+
+        // Assign ids and badge counts to notifications.
+        //
+        var notibadge = app_badge;
+        notifs.sort(by_at);
+        notifs.forEach(function(notif, ix) {
+            notif.id = base_id + ix + 1;
+            if (notif.every)
+                notibadge++;
+            notif.badge = notibadge;
+        });
+
+        return notifs;
+    }
+
+    function notifications_cull_p(remstate, notifs, reports_for_type)
+    {
+        // Return a promise to remove notifications in preparation for
+        // installing new ones. Remove all scheduled notifications.
+        // Also remove any triggered notifications whose associated
+        // reports have been made. The promise resolves to the biggest
+        // id seen.
+        //
+        var ids = [];
+        var maxid = 0;
+        notifs.forEach(function(notif) {
+            if (notif.id > maxid)
+                maxid = notif.id;
+            if (notif.state == 'scheduled') {
+                ids.push(notif.id);
+            } else {
+                var d = new Date(notif.at * 1000); // Epoch time (?)
+                var sd = study_day(remstate, d);
+                if (reports_for_type[notif.data] >= sd)
+                    ids.push(notif.id);
+            }
+        });
+        if (ids.length < 1) {
+            var def = $q.defer();
+            def.resolve(null);
+            return def.promise;
+        }
+        return $cordovaLocalNotification.cancel(ids)
+        .then(function(_) { return maxid; });
+    }
+
+    function sync_p(remstate, reports)
+    {
+        // Return a promise to update notifications and badge count
+        // according to the reminder state and the reports user has
+        // filed. The promise resolves to null.
+        //
+        var sday = study_day_today(remstate);
+        var daysec = sec_after_midnight();
+
+        // How many reports are there of each type?
+        //
+        var reports_for_type = {};
+        remstate.descs.forEach(function(desc) {
+            reports_for_type[desc.type] = 0;
+        });
+        reports.forEach(function(r) {
+            if (!(r.type in reports_for_type))
+                reports_for_type[r.type] = 1;
+            else
+                reports_for_type[r.type]++;
+        });
+
+        // Figure out what the badge count should be for the app.
+        //
+        var app_badge = 0;
+        remstate.descs.forEach(function(desc) {
+            if (desc.reminderonly)
+                return;
+            var due = sday - (daysec >= desc.time ? 0 : 1);
+            app_badge += Math.max(0, due - reports_for_type[desc.type]);
+        });
+
+        // Remove old notifications, schedule new ones, set app badge.
+        //
+        return notifications_now_p()
+        .then(function(notifs) {
+            return notifications_cull_p(remstate, notifs, reports_for_type);
+        })
+        .then(function(maxid) {
+            var notifsn =
+                notifications_new(remstate, reports_for_type, app_badge, maxid);
+            return $cordovaLocalNotification.schedule(notifsn);
+        })
+        .then(function(_) { return $cordovaBadge.set(app_badge); })
+        .then(function(_) { return null; });
+    }
+
+    return {
+        sync: function(descs, start_date, end_date, reports) {
+            // Return a promise to schedule the reminders for a study.
+            // The promise resolves to null.
+            //
+            // descs       Descriptor of the reminders (below)
+            // start_date  Start date (Epoch time, midnight 00:00:00 first day)
+            // end_date    End date (Epoch time, midnight 23:59:59+1 last day)
+            // reports     Current set of reports made by user (if any)
+            //
+            // descs is an array of descriptors that look like this:
+            //
+            // {
+            //     type: type of reminder (= type of report if any)
+            //     reminderonly: no report, just reminder (default false)
+            //     time: time of reminder (number; seconds after midnight)
+            //     heads: heading of reminder (array)
+            //     bodies: body of reminder (array)
+            // }
+            //
+            // The 'type' field of a descriptor gives the type of the
+            // reminder, which (if there is an associated report), is
+            // also the type of the report.
+            //
+            // The 'reminderonly' field, if present, is a boolean saying
+            // whether this is a "pure" reminder with no associated
+            // report.  The default is a "reportable" reminder (false
+            // value for the field).
+            //
+            // For a pure reminder the associated notifications are
+            // created by this module and removed by the user.
+            // Notifications for reportable reminders are removed by
+            // this module when the report is made. (To make this work,
+            // you must call sync() when reports are made.)
+            //
+            // The 'heads' and 'bodies' fields are arrays of text that
+            // should be issued to the user as part of the reminder. If
+            // the arrays have length 1, the same value is used for
+            // every reminder. Otherwise the array length should be the
+            // same as the study duration, giving a value for each day
+            // of the study.
+            //
+            // 'reports' is an array of objects. We require only that
+            // each report have a 'type' field showing the type of the
+            // report. It should be one of the reportable 'type' values
+            // given in the descriptor array.
+            //
+            c_remstate = {};
+            c_remstate.descs = angular.copy(descs);
+            c_remstate.start_date = start_date;
+            c_remstate.end_date = end_date;
+
+            return sync_p(c_remstate, reports);
+        },
+
+        clear: function() {
+            // Return a promise to remove all reminders. The promise
+            // resolves to null.
+            //
+            return $cordovaLocalNotification.cancelAll()
+            .then(function(_) { return null });
+        },
+
+        list: function() {
+            // Return a promise to list all the local notifications. The
+            // promise resolves to an array of notifications in the form
+            // returned by $cordovaLocalNotification, with an added
+            // 'status' field that is either 'triggered' (notification
+            // has been delivered at least once) or 'scheduled'
+            // (notification has never been delivered).
+            //
+            // The array is ordered chronologically by delivery time.
+            //
+            return notifications_now_p()
+            .then(function(notifs) {
+                notifs.sort(by_at);
+                return notifs;
+            });
+        }
+    };
+})
+);


### PR DESCRIPTION
You need to add the plugins for $cordovaLocalNotification and $cordovaBadge

Still need to handle the case where a notification arrives while the app is active. Such notifications are ignored; that's how iOS is designed to treat them. I.e., there's no on-screen message and nothing added to the Notification Center. Need to sign up for notification delivery events to handle them in-app.