### PR TITLE
Rebroadcast Cordova pause/resume as angular events

### DIFF
--- a/TummyTrials/www/index.html
+++ b/TummyTrials/www/index.html
@@ -22,6 +22,7 @@
     <script src="cordova.js"></script>
     <!-- your app's js -->
     <script src="js/app.js"></script>
+    <script src="js/controllers/lifecycle.js"></script>
     <script src="js/controllers/experiments.js"></script>
     <script src="js/controllers/reminders.js"></script>
     <script src="js/controllers/login.js"></script>

--- a/TummyTrials/www/js/app.js
+++ b/TummyTrials/www/js/app.js
@@ -24,7 +24,7 @@ angular.module('starter', ['ionic'])
 'use strict';
 
 var app = angular.module('tummytrials',
-            ['ionic','ngSanitize','tummytrials.login','tummytrials.currentstudy','tummytrials.studysetup','tummytrials.faqcontroller', 'ngCordova','tummytrials.mytrialsctrl', 'tummytrials.ngcordovacontrollers', 'tummytrials.text', 'tummytrials.experiments', 'tummytrials.exper-test', 'tractdb.reminders', 'tummytrials.remind-test']);
+            ['ionic','ngSanitize','tractdb.lifecycle','tummytrials.login','tummytrials.currentstudy','tummytrials.studysetup','tummytrials.faqcontroller', 'ngCordova','tummytrials.mytrialsctrl', 'tummytrials.ngcordovacontrollers', 'tummytrials.text', 'tummytrials.experiments', 'tummytrials.exper-test', 'tractdb.reminders', 'tummytrials.remind-test']);
 
 //Ionic device ready check
 app.run(function($ionicPlatform, $rootScope, $q, Login, Text, Experiments,
@@ -83,8 +83,7 @@ app.run(function($ionicPlatform, $rootScope, $q, Login, Text, Experiments,
     }
 
   });
-
-})
+});
 
 
 //UI-router for handling navigation 

--- a/TummyTrials/www/js/controllers/lifecycle.js
+++ b/TummyTrials/www/js/controllers/lifecycle.js
@@ -1,0 +1,30 @@
+// lifecycle.js     Broadcast app pause/resume events
+//
+// We register for Cordova pause and resume events and rebroadcast them
+// as Angular events from the root scope: appPause, appResume.
+//
+// Note: there are strict limits on what can be done in a handler for
+// appPause. Cordova documentation is here:
+//
+//     https://cordova.apache.org/docs/en/3.0.0/cordova_events_events.md.html
+//
+// Since events are broadcast from the root scope, they should be
+// accessible in any scope. To register for the resume event:
+//
+//     $scope.$on('appResume', function() { things_to_do(); });
+//
+
+'use strict';
+
+(angular.module('tractdb.lifecycle', [])
+.run(function($ionicPlatform, $document, $rootScope) {
+    $ionicPlatform.ready(function() {
+        $document[0].addEventListener("pause", function() {
+            $rootScope.$broadcast('appPause');
+        });
+        $document[0].addEventListener("resume", function() {
+            $rootScope.$broadcast('appResume');
+        });
+    });
+})
+);


### PR DESCRIPTION
iOS apps stay suspended in the background for long periods (for me, on the order of weeks) rather than exiting. When you run them again they restart from where they left off. So you can't imagine doing things like DB replication at app startup; it's too infrequent. But you can access the app pause/resume events that happen when the app moves to/from the background. That's what this (tiny bit of) code is for.

I made new events 'appPause' and 'appResume'. You sign up to receive them by calling $on for some scope (any scope will work):

    $scope.$on('appResume', function() { my_resume_code(); });

Note: the things you can do in a pause handler are very restricted.