### PR TITLE
Turn on replication at startup and resume

### DIFF
--- a/TummyTrials/www/index.html
+++ b/TummyTrials/www/index.html
@@ -23,6 +23,7 @@
     <!-- your app's js -->
     <script src="js/app.js"></script>
     <script src="js/controllers/lifecycle.js"></script>
+    <script src="js/controllers/replicator.js"></script>
     <script src="js/controllers/experiments.js"></script>
     <script src="js/controllers/reminders.js"></script>
     <script src="js/controllers/login.js"></script>

--- a/TummyTrials/www/js/app.js
+++ b/TummyTrials/www/js/app.js
@@ -24,7 +24,7 @@ angular.module('starter', ['ionic'])
 'use strict';
 
 var app = angular.module('tummytrials',
-            ['ionic','ngSanitize','tractdb.lifecycle','tummytrials.login','tummytrials.currentstudy','tummytrials.studysetup','tummytrials.faqcontroller', 'ngCordova','tummytrials.mytrialsctrl', 'tummytrials.ngcordovacontrollers', 'tummytrials.text', 'tummytrials.experiments', 'tummytrials.exper-test', 'tractdb.reminders', 'tummytrials.remind-test']);
+            ['ionic','ngSanitize','tractdb.lifecycle', 'tummytrials.replicator', 'tummytrials.login','tummytrials.currentstudy','tummytrials.studysetup','tummytrials.faqcontroller', 'ngCordova','tummytrials.mytrialsctrl', 'tummytrials.ngcordovacontrollers', 'tummytrials.text', 'tummytrials.experiments', 'tummytrials.exper-test', 'tractdb.reminders', 'tummytrials.remind-test']);
 
 //Ionic device ready check
 app.run(function($ionicPlatform, $rootScope, $q, Login, Text, Experiments,
@@ -40,13 +40,15 @@ app.run(function($ionicPlatform, $rootScope, $q, Login, Text, Experiments,
       // org.apache.cordova.statusbar required
       StatusBar.styleDefault();
     }
-    // Ask for username/password at startup.
-    //
-    Text.all_p()
-    .then(function(text) {
-        return Login.loginfo_p('couchuser', $rootScope, text.loginfo,
-                                Experiments.valid_p);
-    });
+
+// Ask for username/password at startup. Note: this is no longer
+// necessary because we attempt to do replication at startup.
+//
+//  Text.all_p()
+//  .then(function(text) {
+//      return Login.loginfo_p('couchuser', $rootScope, text.loginfo,
+//                              Experiments.valid_p);
+//  });
 
     // Some tests of Experiments. Move these into some kind of framework
     // later on, probably.

--- a/TummyTrials/www/js/controllers/replicator.js
+++ b/TummyTrials/www/js/controllers/replicator.js
@@ -1,0 +1,47 @@
+// replicator.js     Manager of replication
+//
+// This module registers itself to be called whenever the application is
+// resumed (user starts running it again). It implements a policy for
+// replicating the local CouchDB against the central copy.
+//
+// For starters, the policy is just to replicate at every opportunity.
+//
+
+'use strict';
+
+(angular.module('tummytrials.replicator',
+    [ 'tummytrials.text', 'tummytrials.login', 'tummytrials.experiments' ])
+.run(function($ionicPlatform, $rootScope, Text, Login, Experiments) {
+
+    function do_replication()
+    {
+        // We just start replication, don't need to do anything with the
+        // returned promise.
+        //
+        Text.all_p()
+        .then(function(text) {
+            return Login.loginfo_p('couchuser', $rootScope, text.loginfo,
+                                    Experiments.valid_p)
+        })
+        .then(function(unpw) {
+            if (unpw)
+                return Experiments.replicate(unpw);
+            return null;
+        })
+        .then(
+            function good() { return null; },
+            function bad() { return null; }    // Ignore any failure
+        );
+    }
+
+    $ionicPlatform.ready(function() {
+        // Replicate whenever app becomes active.
+        //
+        $rootScope.$on('appResume', do_replication);
+
+        // Also replicate now (at startup).
+        //
+        do_replication();
+    });
+})
+);


### PR DESCRIPTION
I added a small module that does two-way replication at startup and every time the app is resumed. Possibly we will want a more sophisticated policy for when to replicate, but this is a good start.

I tried it with the simulator, and it works for me. It replicated a trial document to tractdb.org, and it repopulated the app from tractdb.org after I deleted and reinstalled the app (in the simulator).

(If you try it, it takes a little while for the replication from tractdb.org to happen when starting from an empty DB. On the order of 20 or 30 seconds it seemed like.)