### PR TITLE
Populate Current Trial & My Trials from DB

### DIFF
--- a/TummyTrials/www/index.html
+++ b/TummyTrials/www/index.html
@@ -22,6 +22,7 @@
     <script src="cordova.js"></script>
     <!-- your app's js -->
     <script src="js/app.js"></script>
+    <script src="js/controllers/lc.js"></script>
     <script src="js/controllers/lifecycle.js"></script>
     <script src="js/controllers/replicator.js"></script>
     <script src="js/controllers/couchdb.js"></script>
@@ -29,7 +30,10 @@
     <script src="js/controllers/reminders.js"></script>
     <script src="js/controllers/login.js"></script>
     <script src="js/controllers/text.js"></script>
+    <script src="js/controllers/studyfmt.js"></script>
+    <script src="js/controllers/currentctrl.js"></script>
     <script src="js/controllers/mytrialsctrl.js"></script>
+    <script src="js/controllers/pasttrial1ctrl.js"></script>
     <script src="js/controllers/currentstudy.js"></script>
     <script src="js/controllers/setupdata.js"></script>
     <script src="js/controllers/setupctrl.js"></script>

--- a/TummyTrials/www/js/app.js
+++ b/TummyTrials/www/js/app.js
@@ -24,11 +24,15 @@ angular.module('starter', ['ionic'])
 'use strict';
 
 var app = angular.module('tummytrials',
-            ['ionic','ngSanitize','ngCordova',
-            'tractdb.lifecycle', 'tummytrials.replicator', 'tummytrials.login','tummytrials.currentstudy',
-            'tummytrials.studysetup','tummytrials.faqcontroller', 'tummytrials.mytrialsctrl', 
-            'tummytrials.ngcordovacontrollers', 'tummytrials.text', 'tummytrials.experiments',
-            'tummytrials.exper-test', 'tractdb.reminders', 'tummytrials.remind-test']);
+            ['ionic', 'ngSanitize', 'ngCordova',
+            'tractdb.lifecycle', 'tummytrials.replicator',
+            'tummytrials.login', 'tummytrials.currentstudy',
+            'tummytrials.studysetup', 'tummytrials.faqcontroller',
+            'tummytrials.currentctrl',
+            'tummytrials.mytrialsctrl', 'tummytrials.pasttrial1ctrl',
+            'tummytrials.ngcordovacontrollers', 'tummytrials.text',
+            'tummytrials.experiments', 'tummytrials.exper-test',
+            'tractdb.reminders', 'tummytrials.remind-test']);
 
 //Ionic device ready check
 app.run(function($ionicPlatform, $rootScope, $q, Login, Text, Experiments,
@@ -134,7 +138,7 @@ app.config(function($stateProvider, $urlRouterProvider) {
       views: {
         current : {
           templateUrl: 'templates/current.html',
-          controller: 'setupcontroller'
+          controller: 'CurrentCtrl'
         }
       }
     })
@@ -148,11 +152,11 @@ app.config(function($stateProvider, $urlRouterProvider) {
       }
     })
     .state('past_trial_1', {
-      url: '/past_trial_1',
+      url: '/past_trial_1/:studyIndex',
       views: {
         mytrials : {
           templateUrl: 'templates/mytrials/past_trial_1.html',
-          controller: 'setupcontroller'
+          controller: 'PastTrial1Ctrl'
         }
       }
     })
@@ -177,20 +181,11 @@ app.config(function($stateProvider, $urlRouterProvider) {
 
 })
 
-app.controller( "setupcontroller", function(Calander, $scope, $http, $sce) {
-    $http({
-        url: 'json/setup.json',
-        dataType: 'json',
-        method: 'GET',
-        data: '',
-        headers: {
-            "Content-Type": "application/json"
-        },
-
-    }).success(function(response){
-        $scope.text = response;
-    }).error(function(error){
-        $scope.text = 'error';
+app.controller("setupcontroller", function($scope, $http, $sce, Text, Experiments, Calander) {
+    Text.all_p()
+    .then(function(text){
+        $scope.text = text;
+        return Experiments.publish_p($scope);
     });
 
     this.calander = [];

--- a/TummyTrials/www/js/controllers/currentctrl.js
+++ b/TummyTrials/www/js/controllers/currentctrl.js
@@ -1,0 +1,75 @@
+// currentctrl.js     Controller for 'Current Trial' tab
+//
+
+'use strict';
+
+(angular.module('tummytrials.currentctrl',
+                ['tummytrials.lc', 'tummytrials.text',
+                 'tummytrials.experiments'])
+
+.controller('CurrentCtrl', function($scope, LC, Text, Experiments) {
+    Text.all_p()
+    .then(function(text) {
+        $scope.text = text;
+        return Experiments.publish_p($scope);
+    })
+    .then(function(_) {
+        var text = $scope.text;
+        var cur = $scope.study_current;
+        $scope.study_reminders = [];
+        if (cur && cur.remdescrs) {
+            // Info for reminders.
+            //     reportdue  report is due (bool)
+            //     disabled   button (if any) should be disabled (bool)
+            //     schedmsg   ex: 'Your breakfast reminder is set for 9 am.'
+            //     logmsg     ex: 'Log Breakfast Compliance' (can be null)
+            //     logstate   ex: 'during' (angular-ui state for logging)
+            //
+            var rinfo = [];
+            cur.remdescrs.forEach(function(rd) {
+                var info = {};
+                // XXX The idea here is to track whether there's a
+                // report due for the reminder. Need to fix up when
+                // reports are working.
+                //
+                info.reportdue = !rd.reminderonly;
+                var msg, name;
+                msg = text.current.reminder_schedule_template;
+                name = text.current[rd.type + '_reminder_name'] || rd.type;
+                msg = msg.replace('{NAME}', name);
+                msg = msg.replace('{WHEN}', LC.timestr(rd.time || 0));
+                info.schedmsg = msg;
+                if (rd.reminderonly) {
+                    info.logmsg = null;
+                    info.logstate = 'none';
+                } else {
+                    info.logmsg = text.current[rd.type + '_reminder_logmsg'];
+                    info.logmsg = info.logmsg || ('Log ' + rd.type);
+                    switch(rd.type) {
+                        case 'breakfast': info.logstate = 'during'; break;
+                        case 'symptomEntry': info.logstate = 'post'; break;
+                        default: info.logstate = 'none'; break;
+                    }
+                }
+                rinfo.push(info);
+            });
+
+            // Want to disable all but the first button for which a
+            // report is due.
+            //
+            var enable = true;
+            rinfo.forEach(function(ri) {
+                if (ri.reportdue && enable) {
+                    ri.disabled = false;
+                    enable = false;
+                } else {
+                    ri.disabled = true;
+                }
+            });
+
+            $scope.study_reminders = rinfo;
+        }
+    });
+})
+
+);

--- a/TummyTrials/www/js/controllers/lc.js
+++ b/TummyTrials/www/js/controllers/lc.js
@@ -1,0 +1,43 @@
+// lc.js     Formatting functions that should probably be localized someday
+//
+
+'use strict';
+
+(angular.module('tummytrials.lc', [])
+    .factory('LC', function() {
+        return {
+            datestr: function(d) {
+                // Return a string for the date. It looks like
+                // "Tue, Nov 3".
+                //
+                var days = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+                var mons = ["Jan","Feb","Mar","Apr","May","Jun",
+                            "Jul","Aug","Sep","Oct","Nov","Dec"];
+                return days[d.getDay()] + ", " + mons[d.getMonth()] + " " +
+                        d.getDate();
+            },
+
+            timestr: function(sec) {
+                // Return string for the given number of seconds after
+                // midnight. It looks like '9:15 am'.
+                //
+                var hrs = Math.floor(sec / 3600);
+                var min = Math.floor((sec % 3600) / 60);
+                var ampm = 'am';
+
+                if (hrs == 0) {
+                    hrs = 12;
+                    if (min == 0)
+                        ampm = 'midnight';
+                } else if (hrs == 12 && min == 0) {
+                    ampm = 'noon';
+                } else if (hrs >= 12) {
+                    if (hrs > 12) hrs -= 12;
+                    ampm = 'pm';
+                }
+
+                return hrs + ':' + ('0' + String(min)).substr(-2) + ' ' + ampm;
+            }
+        };
+    })
+);

--- a/TummyTrials/www/js/controllers/mytrialsctrl.js
+++ b/TummyTrials/www/js/controllers/mytrialsctrl.js
@@ -5,10 +5,7 @@
     Text.all_p()
     .then(function(text) {
         $scope.text = text;
-        return Experiments.getCurrent();
-    })
-    .then(function(curexper) {
-        $scope.current_experiment = curexper;
+        return Experiments.publish_p($scope);
     });
 })
 

--- a/TummyTrials/www/js/controllers/pasttrial1ctrl.js
+++ b/TummyTrials/www/js/controllers/pasttrial1ctrl.js
@@ -1,0 +1,24 @@
+(angular.module('tummytrials.pasttrial1ctrl',
+                ['tummytrials.text', 'tummytrials.experiments',
+                 'tummytrials.studyfmt'])
+
+.controller('PastTrial1Ctrl', function($scope, $stateParams,
+                                        Text, Experiments, StudyFmt) {
+    Text.all_p()
+    .then(function(text) {
+        $scope.text = text;
+        return Experiments.publish_p($scope);
+    })
+    .then(function(_) {
+        var study = $scope.study_previous[$stateParams.studyIndex];
+        $scope.study_past1 = study;
+        return StudyFmt.new_p(study);
+    })
+    .then(function(studyfmt) {
+        $scope.study_topic_question = studyfmt.topicQuestion();
+        $scope.study_date_range = studyfmt.dateRange();
+        $scope.study_reminder_times = studyfmt.reminderTimes();
+    });
+})
+
+);

--- a/TummyTrials/www/js/controllers/reminders.js
+++ b/TummyTrials/www/js/controllers/reminders.js
@@ -310,6 +310,7 @@
             app_badge += Math.max(0, due - reports_for_type[desc.type]);
         });
 
+
         // Remove all old notifications, schedule new ones, set app
         // badge.
         //

--- a/TummyTrials/www/js/controllers/studyfmt.js
+++ b/TummyTrials/www/js/controllers/studyfmt.js
@@ -1,0 +1,68 @@
+// studyfmt.js     Human-readable properties of a study
+//
+// (The idea is that these functions might be useful in more than one
+// controller.)
+//
+
+'use strict';
+
+(angular.module('tummytrials.studyfmt',
+                [ 'tummytrials.lc', 'tummytrials.text' ])
+
+.factory('StudyFmt', function(LC, Text) {
+
+    // Constructor (private). Callers should use new_p().
+    //
+    function StudyFmt(study)
+    {
+        this.study = study;
+    }
+
+
+    StudyFmt.prototype = {};
+
+    // Public class method.
+    //
+    StudyFmt.new_p = function(study) {
+        // Return a promise for a new study formatter.
+        //
+        return Text.all_p()
+        .then(function(text) {
+            var studyfmt = new StudyFmt(study);
+            studyfmt.text = text;
+            return studyfmt;
+        });
+    }
+
+    // Public instance methods.
+    //
+    StudyFmt.prototype.topicQuestion = function() {
+        // Return the question being studied, or null if there isn't
+        // one. Example: "Does drinking caffeine affect my symptoms?"
+        //
+        if (!this.study.trigger)
+            return null;
+        var lowtrigger = this.study.trigger.toLowerCase();
+        return this.text.setup5.topic.replace('{TRIGGER}', lowtrigger);
+    }
+
+    StudyFmt.prototype.dateRange = function() {
+        var sd = new Date(this.study.start_time * 1000);
+        // (Last day of study, not first day after study.)
+        var ed = new Date((this.study.end_time - 8 * 60 * 60) * 1000);
+        return LC.datestr(sd) + ' — ' + LC.datestr(ed);
+    }
+
+    StudyFmt.prototype.reminderTimes = function() {
+        var res = {};
+
+        if (this.study.remdescrs)
+            this.study.remdescrs.forEach(function(remdescr) {
+                res[remdescr.type] = LC.timestr(remdescr.time);
+            });
+        return res;
+    }
+
+    return StudyFmt;
+})
+)

--- a/TummyTrials/www/json/setup.json
+++ b/TummyTrials/www/json/setup.json
@@ -9,7 +9,13 @@
 		"note" : "Would you like to add an optional note?",
 		"button1": "Log Breakfast Compliance",
 		"button2": "Log Symptom Level",
-		"button3": "Add Notes"
+		"button3": "Add Note",
+                "reminder_schedule_template": "Your {NAME} reminder is set to {WHEN}.",
+                "morning_reminder_name": "morning",
+                "breakfast_reminder_name": "breakfast",
+                "symptomEntry_reminder_name": "symptom entry",
+                "breakfast_reminder_logmsg": "Log Breakfast Compliance",
+                "symptomEntry_reminder_logmsg": "Log Symptom Level"
 	},	
 	"no_study": {
 		"title": "No ongoing study",
@@ -224,7 +230,7 @@
 		"topic_title": "Self-Study Topic",
                 "notopic": "(Please select trigger on screen 2.)",
 		"topic": "Does {TRIGGER} affect my symptoms?",
-		"sypmtoms_title": "Symptoms Being Tracked",
+		"symptoms_title": "Symptoms Being Tracked",
 		"symptom1": "- Abdominal Pain",
 		"symptom2": "- Bloating or Gas",
                 "nosymptom": "(Please select symptoms on screen 1.)",
@@ -232,9 +238,11 @@
                 "nolength": "(Please select a length and start date on screen 3.)",
 		"start_date": "Tue Mar 27th",
 		"end_date": "Tue Apr 4th",
-		"morning_reminder_title": "Morning Reminder Time",
+                "reminder_times_title": "Reminder Times",
+		"morning_reminder_title": "Morning Reminder",
 		"morning_reminder": "9:00 am",
-		"symptom_reminder_title": "Symptom Entry Reminder Time",
+                "breakfast_reminder_title": "Breakfast Reminder",
+		"symptomEntry_reminder_title": "Symptom Entry Reminder",
 		"symptom_reminder": "1:00 pm",
 		"button": "Begin Study!"
 	},
@@ -245,5 +253,9 @@
                 "passtag": "Password",
                 "loginb": "Login",
                 "cancelb": "Cancel"
+        },
+        "pasttrial1": {
+                "status_title": "Status",
+                "notes_title": "Notes"
         }
 }

--- a/TummyTrials/www/templates/current.html
+++ b/TummyTrials/www/templates/current.html
@@ -40,6 +40,22 @@
       <li ng-repeat="rem in text.current.reminders"><p><i class="ion-ios-circle-outline"></i> {{rem.rem}}</p></li>
     </ul> -->
     <h4>Your reminders for today:</h4>
+    <!-- XXX In later commit, change contents of the whole page. -->
+    <p ng-show="!study_current">(Actually, there is no current trial.)</p>
+    <div ng-repeat="rem in study_reminders">
+        <p>
+        <i class="ion-ios-checkmark" ng-hide="rem.reportdue" style="font-size: 120%;"></i>
+        <i class="ion-ios-circle-outline" ng-show="rem.reportdue" style="font-size: 120%;"></i>
+        {{rem.schedmsg}}
+        <div class="divcenter" ng-show="!!rem.logmsg">
+            <a class="button button-royal" ui-sref="{{rem.logstate}}" ng-disabled="rem.disabled">
+                {{rem.logmsg}}
+            </a>
+        </div>
+        </p>
+        <br/>
+    </div>
+    <!-- Previously
       <p><i class="ion-ios-checkmark"></i> {{text.current.rem1}}</p>
       <p>
         <i class="ion-ios-circle-outline"></i><b> {{text.current.rem2}}</b>
@@ -58,6 +74,7 @@
         </div>
       </p>
       <br/>
+     -->
 
 
     <h4>Optional:</h4>

--- a/TummyTrials/www/templates/mytrials.html
+++ b/TummyTrials/www/templates/mytrials.html
@@ -17,7 +17,7 @@
 		<a class="button button-block button-energized" ui-sref="setup_1">
             {{text.mytrials.button}}
         </a> -->
-        <div class="padding" ng-hide="!!current_experiment">
+        <div class="padding" ng-hide="!!study_current">
 	        <h4 class="title">No ongoing trial</h4>
 			<br/>
 			<p>Would you like to setup a new trial?</p>
@@ -34,19 +34,22 @@
 		  <div class="item item-divider">
 		    {{text.mytrials.currenttrialtitle}}
 		  </div>
-		  <a class="item" href="#" ng-hide="current_experiment">
+		  <a class="item" href="#" ng-hide="!!study_current">
 		    There is no ongoing trial.
 		  </a>
-		  <a class="item" href="#" ng-show="current_experiment">
-		    {{current_experiment.name}}
+		  <a class="item" href="#" ng-show="!!study_current">
+		    {{study_current.name}}
 		  </a>
 
 		  <div class="item item-divider">
 		    {{text.mytrials.pasttrialtitle}}
 		  </div>
-		  <a class="item" ui-sref="past_trial_1">
-		    Results page.
+                  <a class="item" ng-repeat="study in study_previous" ui-sref="past_trial_1({studyIndex: $index})" ng-hide="study_previous.length<1">
+		    <h2>{{study.name}}</h2>
 		  </a>
+                  <div class="item" ng-show="study_previous.length<1">
+                    There are no past trials.
+                  </div>
 
 		</div>
 

--- a/TummyTrials/www/templates/mytrials/past_trial_1.html
+++ b/TummyTrials/www/templates/mytrials/past_trial_1.html
@@ -1,12 +1,41 @@
-<ion-view title="Past Trial">
+<ion-view>
+  <ion-nav-title>
+  {{study_past1.name}}
+  </ion-nav-title>
   <ion-pane>
     <ion-content class="padding">
-        <br/>
-    <h4 class="title"></h4>
+
+    <h5 class="title">{{text.setup5.topic_title}}</h5>
+    <p>{{study_topic_question}}</p>
     <br/>
-    <p>{{text.post.subtitle}}</p>
+
+    <h5 class="title">{{text.setup5.symptoms_title}}</h5>
+    <p ng-repeat="symptom in study_past1.symptoms">
+    {{symptom}}
+    </p>
     <br/>
-    Something to see.
+
+    <h5 class="title">{{text.setup5.study_length}}</h5>
+    <p>{{study_date_range}}</p>
+    <br/>
+
+    <h5 class="title">{{text.setup5.reminder_times_title}}</h5>
+    <div class="row" ng-repeat="remdesc in study_past1.remdescrs">
+        <div class="col">{{text.setup5[remdesc.type + '_reminder_title'] || remdesc.type}}</div>
+        <div class="col">{{study_reminder_times[remdesc.type]}}</div>
+    </div>
+    <br/>
+
+    <h5 class="title">{{text.pasttrial1.status_title}}</h5>
+    <p>{{study_past1.status}}</p>
+    <br/>
+
+    <div ng-show="study_past1.comment != ''">
+    <h5 class="title">{{text.pasttrial1.notes_title}}</h5>
+    <p>{{study_past1.comment}}</p>
+    </div>
+    <br/>
+
     </ion-content>  
   </ion-pane>
 </ion-view>

--- a/TummyTrials/www/templates/study_setup/setup_5.html
+++ b/TummyTrials/www/templates/study_setup/setup_5.html
@@ -7,7 +7,7 @@
               <p>{{chosen_topic}}</p>
               <br/>
 
-              <h5 class="title">{{text.setup5.sypmtoms_title}}</h5>
+              <h5 class="title">{{text.setup5.symptoms_title}}</h5>
               <p ng-repeat="symptom in chosen_symptoms">{{symptom}}</p>
               <br/>
 
@@ -15,13 +15,11 @@
               <p>{{chosen_date_range}}</p>              
               <br/>
 
-              <h5 class="title">{{text.setup5.morning_reminder_title}}</h5>
-              <p>{{text.setup5.morning_reminder}}</p>
-              <br/>
-
-              <h5 class="title">{{text.setup5.symptom_reminder_title}}</h5>
-              <p>{{text.setup5.symptom_reminder}}</p>              
-              <br/>
+              <h5 class="title">{{text.setup5.reminder_times_title}}</h5>
+              <div class="row" ng-repeat="remdesc in study.remdescrs">
+                <div class="col">{{text.setup5[remdesc.type + '_reminder_title'] || remdesc.type}}</div>
+                <div class="col">{{chosen_reminder_times[remdesc.type]}}</div>
+              </div>
               
               <a class="button button-block button-royal" ng-disabled="!study_data_complete" ng-click="begin_study()">
                 {{text.setup5.button}}


### PR DESCRIPTION
Populate the Current Trial and My Trials pages from the DB. The Current Trial page looks almost unchanged, but the data (such as scheduled reminder times) is coming from the DB.

If you have some old trials in the DB, the My Trials page is pretty cool now (in my tests at least).
