### PR TITLE
Breakfast and symptom logging to DB

### DIFF
--- a/TummyTrials/www/index.html
+++ b/TummyTrials/www/index.html
@@ -32,6 +32,7 @@
     <script src="js/controllers/text.js"></script>
     <script src="js/controllers/studyfmt.js"></script>
     <script src="js/controllers/currentctrl.js"></script>
+    <script src="js/controllers/loggingctrl.js"></script>
     <script src="js/controllers/mytrialsctrl.js"></script>
     <script src="js/controllers/pasttrial1ctrl.js"></script>
     <script src="js/controllers/currentstudy.js"></script>

--- a/TummyTrials/www/js/app.js
+++ b/TummyTrials/www/js/app.js
@@ -54,41 +54,32 @@ app.run(function($ionicPlatform, $rootScope, $q, Login, Text, Experiments,
   //
   Experiments.getCurrent()
   .then(function(curex) {
-    var rd, st, et, rc;
+    var rd, st, et, rt;
 
-    if (curex && curex.remdescrs && curex.start_time && curex.end_time &&
-        curex.reports) {
+    if (curex && curex.remdescrs && curex.start_time && curex.end_time) {
         // Current experiment looks good.
         //
         rd = curex.remdescrs;
         st = curex.start_time;
         et = curex.end_time;
-        rc = {};
-        // XXX Adapt to new report definition.
-        //
-        curex.reports.forEach(function(r) {
-            if (!(r.type in rc))
-                rc[r.type] = 1;
-            else
-                rc[r.type]++;
-        });
+        rt = Experiments.report_tally(curex);
     } else {
         // No current experiment.
         //
         rd = [];
         st = 0;
         et = 0;
-        rc = {};
+        rt = {};
     }
   
-    return Reminders.sync(rd, st, et, rc)
+    return Reminders.sync(rd, st, et, rt)
     .then(function(_) {
         // Validate that proper reminders have been scheduled (if
         // desired).
         //
         var want_to_validate = true; // Maybe false in production?
         if (want_to_validate)
-            return RemindTest.validateSync(rd, st, et, rc);
+            return RemindTest.validateSync(rd, st, et, rt);
         else
             return null;
     });
@@ -105,7 +96,9 @@ app.run(function($ionicPlatform, $rootScope, $q, Login, Text, Experiments,
         .then(ExperTest.testGetCurrent)
         .then(ExperTest.testAdd)
         .then(ExperTest.testSetStatus)
-        .then(ExperTest.testAddReport)
+        .then(ExperTest.testGetReports)
+        .then(ExperTest.testGetReport)
+        .then(ExperTest.testPutReport)
         .then(ExperTest.testDelete)
         .then(
             function good() {},

--- a/TummyTrials/www/js/controllers/couchdb.js
+++ b/TummyTrials/www/js/controllers/couchdb.js
@@ -495,6 +495,7 @@ var DB_DOCVERSION = 1;
             })
             .then(
                 function(ra) {
+                    console.log('replication complete');
                     _this.replication_prom = null;
                     return null;
                 },
@@ -505,7 +506,7 @@ var DB_DOCVERSION = 1;
                     return null;
                 }
             );
-        return replication_prom;
+        return this.replication_prom;
     }
 
     CouchDB.prototype.replicating = function() {

--- a/TummyTrials/www/js/controllers/currentctrl.js
+++ b/TummyTrials/www/js/controllers/currentctrl.js
@@ -4,8 +4,8 @@
 'use strict';
 
 (angular.module('tummytrials.currentctrl',
-                ['tummytrials.lc', 'tummytrials.text',
-                 'tummytrials.experiments'])
+                [ 'tummytrials.lc', 'tummytrials.text',
+                  'tummytrials.experiments' ])
 
 .controller('CurrentCtrl', function($scope, LC, Text, Experiments) {
     Text.all_p()
@@ -20,19 +20,55 @@
         if (cur && cur.remdescrs) {
             // Info for reminders.
             //     reportdue  report is due (bool)
-            //     disabled   button (if any) should be disabled (bool)
             //     schedmsg   ex: 'Your breakfast reminder is set for 9 am.'
-            //     logmsg     ex: 'Log Breakfast Compliance' (can be null)
+            //     logmsg     ex: 'Log Breakfast Compliance' (null => no button)
+            //     disabled   button should be disabled (bool)
             //     logstate   ex: 'during' (angular-ui state for logging)
             //
             var rinfo = [];
+
+            // If the user falls behind in reporting, there can be
+            // reports due for days in the past. Or there can be reports
+            // due now or sometime later today. We'll guide the user to
+            // make the earliest such report. So figure out its type.
+            //
+            var rep_type = null; // Next report to make; null => done thru today
+            var sdn = Math.min(Experiments.study_day_today(cur),
+                               Experiments.study_duration(cur));
+
+            found: for (var sd = 1; sd <= sdn; sd++) {
+                if (!cur.reports || !cur.reports[sd - 1]) {
+                    // No report object at all; so, first report of day
+                    // is earliest report due.
+                    //
+                    for (var i = 0; i < cur.remdescrs.length; i++) {
+                        if (!cur.remdescrs[i].reminderonly) {
+                            rep_type = cur.remdescrs[i].type;
+                            break found;
+                        }
+                    }
+                    break found; // (No reportable reminders at all?)
+                }
+                var rsd = cur.reports[sd - 1];
+                for (var i = 0; i < cur.remdescrs.length; i++) {
+                    if (cur.remdescrs[i].reminderonly)
+                        continue;
+                    var ty = cur.remdescrs[i].type;
+                    if (!Experiments.report_made(rsd, ty)) {
+                        rep_type = ty;
+                        break found;
+                    }
+                }
+            }
+
+            var rep_tally = Experiments.report_tally(cur);
+
             cur.remdescrs.forEach(function(rd) {
                 var info = {};
-                // XXX The idea here is to track whether there's a
-                // report due for the reminder. Need to fix up when
-                // reports are working.
-                //
-                info.reportdue = !rd.reminderonly;
+                info.reportdue =
+                    !rd.reminderonly &&
+                    rep_tally[rd.type] < Experiments.study_day_today(cur);
+                info.disabled = rd.type != rep_type;
                 var msg, name;
                 msg = text.current.reminder_schedule_template;
                 name = text.current[rd.type + '_reminder_name'] || rd.type;
@@ -52,19 +88,6 @@
                     }
                 }
                 rinfo.push(info);
-            });
-
-            // Want to disable all but the first button for which a
-            // report is due.
-            //
-            var enable = true;
-            rinfo.forEach(function(ri) {
-                if (ri.reportdue && enable) {
-                    ri.disabled = false;
-                    enable = false;
-                } else {
-                    ri.disabled = true;
-                }
             });
 
             $scope.study_reminders = rinfo;

--- a/TummyTrials/www/js/controllers/currentstudy.js
+++ b/TummyTrials/www/js/controllers/currentstudy.js
@@ -1,4 +1,5 @@
-(angular.module('tummytrials.currentstudy',['ionic'])
+(angular.module('tummytrials.currentstudy',
+                [ 'ionic', 'tummytrials.loggingctrl' ])
 
 .config(function($stateProvider, $urlRouterProvider) {
 
@@ -17,7 +18,7 @@
       views: {
         current : {
           templateUrl: 'templates/currenttrial/during.html',
-          controller: 'setupcontroller'
+          controller: 'LogDuringCtrl'
         }
       }
     })     
@@ -26,7 +27,7 @@
       views: {
         current : {
           templateUrl: 'templates/currenttrial/post.html',
-          controller: 'setupcontroller'
+          controller: 'LogPostCtrl'
         }
       }
     }) 

--- a/TummyTrials/www/js/controllers/exper-test.js
+++ b/TummyTrials/www/js/controllers/exper-test.js
@@ -1,46 +1,60 @@
 // exper-test.js     Some tests of the experiments module
 //
+
+'use strict';
+
 (angular.module('tummytrials.exper-test', [ 'tummytrials.experiments' ])
 
 .factory('ExperTest', function($q, Experiments) {
 
-    function deep_equals(a, b)
-    {
-        // Compare a, b for equality. This borders on the impossible for
-        // arbitrary JavaScript values. As a simplification, assume that
-        // a and b can be fully represented in JSON.
-        //
-        var i;
+//  OBSOLETE: use angular.equals() instead.
+//
+//  function deep_equals(a, b)
+//  {
+//      // Compare a, b for equality. This borders on the impossible for
+//      // arbitrary JavaScript values. As a simplification, assume that
+//      // a and b can be fully represented in JSON.
+//      //
+//      var i;
 
-        if (Object(a) !== a || Object(b) !== b)
-            return a === b;
-        if (typeof a == 'function' || typeof b == 'function')
-            return false; // This violates JSON assumption
-        if (Array.isArray(a) || Array.isArray(b)) {
-            if (!Array.isArray(a) || !Array.isArray(b) || a.length != b.length)
-                return false;
-            for (i = 0; i < a.length; i++)
-                if (!deep_equals(a[i], b[i]))
-                    return false;
-            return true;
-        }
-        var aps = Object.getOwnPropertyNames(a);
-        for (i = 0; i < aps.length; i++)
-            if (    !b.hasOwnProperty(aps[i]) ||
-                    !deep_equals(a[aps[i]], b[aps[i]]))
-                return false;
-        var bps = Object.getOwnPropertyNames(b);
-        for (i = 0; i < bps.length; i++)
-            if (!a.hasOwnProperty(bps[i]))
-                return false;
-        return true;
-    }
+//      if (Object(a) !== a || Object(b) !== b)
+//          return a === b;
+//      if (typeof a == 'function' || typeof b == 'function')
+//          return false; // This violates JSON assumption
+//      if (Array.isArray(a) || Array.isArray(b)) {
+//          if (!Array.isArray(a) || !Array.isArray(b) || a.length != b.length)
+//              return false;
+//          for (i = 0; i < a.length; i++)
+//              if (!deep_equals(a[i], b[i]))
+//                  return false;
+//          return true;
+//      }
+//      var aps = Object.getOwnPropertyNames(a);
+//      for (i = 0; i < aps.length; i++)
+//          if (    !b.hasOwnProperty(aps[i]) ||
+//                  !deep_equals(a[aps[i]], b[aps[i]]))
+//              return false;
+//      var bps = Object.getOwnPropertyNames(b);
+//      for (i = 0; i < bps.length; i++)
+//          if (!a.hasOwnProperty(bps[i]))
+//              return false;
+//      return true;
+//  }
 
     function by_revchrono(a, b)
     {
         if (a.start_time < b.start_time) return 1;
         if (a.start_time > b.start_time) return -1;
         return 0;
+    }
+
+    function const_p(k)
+    {
+        // Return a promise that resolves to k.
+        //
+        var def = $q.defer();
+        def.resolve(k);
+        return def.promise;
     }
 
     function test_exper(n)
@@ -117,13 +131,31 @@
         return add_i_p(0);
     }
 
-    function const_p(k)
+    function test_report(n)
     {
-        // Return a promise that resolves to k.
+        // Return a report object for study day n. There's an extra
+        // "check" field to help assure we get back what we put in.
         //
-        var def = $q.defer();
-        def.resolve(k);
-        return def.promise;
+        return { study_day: n, check: 1299827 * n };
+    }
+
+    function add_test_reports_p(id, ns)
+    {
+        // Return a promise to add test reports with the give day
+        // numbers to the experiment with the given id. The promise
+        // resolves to null.
+        //
+        function add_i_p(i)
+        {
+            if (i >= ns.length)
+                return const_p(null);
+            return Experiments.put_report_p(id, test_report(ns[i]))
+            .then(function(_) {
+                return add_i_p(i + 1);
+            });
+        }
+
+        return add_i_p(0);
     }
 
     function cleanup_expers_p(ids, i)
@@ -152,7 +184,7 @@
 
     function validate_exper_equal(a, b, tag)
     {
-        if (!deep_equals(a, b)) {
+        if (!angular.equals(a, b)) {
             console.log('validate_exper_equal<' + tag + '>: failure');
             throw new Error('validate_exper_equal<' + tag + '>');
         }
@@ -161,11 +193,29 @@
 
     function validate_expers_equal(as, bs, tag)
     {
-        if (!deep_equals(as, bs)) {
+        if (!angular.equals(as, bs)) {
             console.log('validate_expers_equal<' + tag + '>: failure');
             throw new Error('validate_expers_equal<' + tag + '>');
         }
         console.log('validate_expers_equal<' + tag + '>: success');
+    }
+
+    function validate_report_equal(a, b, tag)
+    {
+        if (!angular.equals(a, b)) {
+            console.log('validate_report_equal<' + tag + '>: failure');
+            throw new Error('validate_report_equal<' + tag + '>');
+        }
+        console.log('validate_report_equal<' + tag + '>: success');
+    }
+
+    function validate_reports_equal(as, bs, tag)
+    {
+        if (!angular.equals(as, bs)) {
+            console.log('validate_reports_equal<' + tag + '>: failure');
+            throw new Error('validate_reports_equal<' + tag + '>');
+        }
+        console.log('validate_reports_equal<' + tag + '>: success');
     }
 
     return {
@@ -371,35 +421,137 @@
             );
         },
 
-        testAddReport: function() {
+        testGetReports: function() {
             var n = 182; // Any n should be OK
-            var report = { time: 0 };
             var xids;
 
             return add_test_expers_p([n])
             .then(function(ids) {
                 xids = ids;
-                return Experiments.get(xids[0]);
+                return Experiments.get_reports_p(xids[0]);
             })
-            .then(function(exper) {
-                var a = test_exper_full(n, xids[0]);
-                validate_exper_equal(a, exper, 'testAddReport 0');
-                report.time = a.start_time + 24 * 3600;
-                return Experiments.addReport(xids[0], report);
+            .then(function(reps) {
+                validate_reports_equal([], reps, 'testGetReports 0');
+                return Experiments.put_report_p(xids[0], test_report(2));
             })
-            .then(function(ct) {
-                if (ct == 1) {
-                    console.log('testAddReport 1 (count) success');
-                } else {
-                    console.log('testAddReport 1 (count) failure');
-                }
-                return Experiments.get(xids[0]);
+            .then(function(_) {
+                return Experiments.get_reports_p(xids[0]);
             })
-            .then(function(exper) {
-                var a = test_exper_full(n, xids[0]);
-                a.reports.push(report);
-                validate_exper_equal(a, exper, 'testAddReport 2');
+            .then(function(reps) {
+                validate_reports_equal([null, test_report(2)], reps,
+                                        'testGetReports 1');
                 return null;
+            })
+            .then(
+                function good(_) {
+                    return cleanup_expers_p(xids, 0);
+                },
+                function bad(err) {
+                    return cleanup_expers_p(xids, 0)
+                    .then(function(_) { throw err; });
+               }
+            );
+        },
+
+        testGetReport: function() {
+            var n = 183;     // Any n should be OK
+            var ds = [2, 3]; // Study days
+            var xids;
+
+            return add_test_expers_p([n])
+            .then(function(ids) {
+                xids = ids;
+                return Experiments.get_report_p(xids[0], 1);
+            })
+            .then(function(rep) {
+                if (rep === null) {
+                    console.log('testGetReport 0 (nonexist) success');
+                } else {
+                    console.log('testGetReport 0 (nonexist) failure');
+                }
+                return add_test_reports_p(xids[0], ds);
+            })
+            .then(function(_) {
+                var proms = [];
+                for (var i = 0; i < 5; i++)
+                    proms[i] = Experiments.get_report_p(xids[0], i);
+                return $q.all(proms);
+            })
+            .then(function(repar) {
+                for (var i = 0; i < 5; i++)
+                    if (ds.indexOf(i) >= 0) {
+                        validate_report_equal(repar[i], test_report(i),
+                            'testGetReport 1, ' + i);
+                    } else {
+                        if (repar[i] === null) {
+                            console.log('testGetReport 1,', i, 'success');
+                        } else {
+                            console.log('testGetReport 1,', i, 'failure');
+                        }
+                    }
+                return null;
+            })
+            .then(
+                function good(_) {
+                    return cleanup_expers_p(xids, 0);
+                },
+                function bad(err) {
+                    return cleanup_expers_p(xids, 0)
+                    .then(function(_) { throw err; });
+               }
+            );
+        },
+
+        testPutReport: function() {
+            var n = 184;     // Any n should be OK
+            var ds = [2, 5]; // Study days
+            var xids;
+
+            function verif_i_p(i)
+            {
+                // Verify adding a report for each day in ds[].
+                //
+                if (i >= ds.length)
+                    return const_p(null);
+                return Experiments.put_report_p(xids[0], test_report(ds[i]))
+                .then(function(_) {
+                    return Experiments.get_reports_p(xids[0]);
+                })
+                .then(function(reps) {
+                    var expected = [];
+                    for (var j = 0; j <= i; j++)
+                        expected[ds[j] - 1] = test_report(ds[j]);
+                    // (Simulate CouchDB storage and retrieval.)
+                    expected = JSON.parse(JSON.stringify(expected));
+                    validate_reports_equal(expected, reps,
+                        'testPutReport 1, ' + i);
+                    return verif_i_p(i + 1);
+                });
+            }
+
+            return add_test_expers_p([n])
+            .then(function(ids) {
+                xids = ids;
+                return Experiments.get_reports_p(xids[0]);
+            })
+            .then(function(reps) {
+                validate_reports_equal([], reps, 'testPutReport 0');
+                return verif_i_p(0);
+            })
+            .then(function(_) {
+                return Experiments.put_report_p(xids[0], test_report(0))
+                .then(
+                    function notsogood() {
+                        // Good is bad; not supposed to work
+                        console.log('testPutReport 2 invalid day failure');
+                        throw new Error('testPutReport 2 invalid day failure');
+                    },
+                    function notsobad() {
+                        // Bad is good
+                        console.log('testPutReport 2 invalid day success');
+                        return null;
+                    }
+                );
             })
             .then(
                 function good(_) {

--- a/TummyTrials/www/js/controllers/loggingctrl.js
+++ b/TummyTrials/www/js/controllers/loggingctrl.js
@@ -1,0 +1,239 @@
+// loggingctrl.js     Controllers for logging daily study results
+//
+// (These are known as reports in the code.)
+//
+
+(angular.module('tummytrials.loggingctrl',
+                [ 'tractdb.reminders', 'tummytrials.text', 'tummytrials.lc',
+                  'tummytrials.experiments' ])
+
+.controller('LogDuringCtrl', function($scope, $state, $ionicHistory,
+                                    Reminders, Text, LC, Experiments) {
+    var text;
+    var logday; // What study day is being logged
+
+    function make_report(compliant)
+    {
+        var cur = $scope.study_current;
+
+        Experiments.get_report_p(cur.id, logday)
+        .then(function(report) {
+            if (!report) report = {};
+            report.study_day = logday;
+            report.breakfast_compliance = compliant;
+            report.breakfast_report_time = Math.floor(Date.now() / 1000);
+            return Experiments.put_report_p(cur.id, report);
+        })
+        .then(function(_) {
+            // Refetch current study with report.
+            //
+            return Experiments.get(cur.id);
+        })
+        .then(function(curex) {
+            // Sync the reminder state with new version of study.
+            //
+            var rd = curex.remdescrs;
+            var st = curex.start_time;
+            var et = curex.end_time;
+            var rt = Experiments.report_tally(curex);
+            return Reminders.sync(rd, st, et, rt);
+        })
+        .then(function(_) {
+            var state = compliant ? 'pos_compliance' : 'neg_compliance';
+        
+            // { location: 'replace' } is documented to replace our
+            // current state in the history stack with the new state.
+            // The new back button should skip over this log page and
+            // lead back to the main screen for the current trial. This
+            // apparently works in ui-routing, but the Ionic back button
+            // doesn't work right. There have been calls to fix it for a
+            // couple of years. The following is a hack from the Ionic
+            // GitHub issue discussion:
+            //
+            //     https://github.com/driftyco/ionic/issues/1287
+            //
+            // If it stops working, maybe get a similar effect by
+            // reloading the current state with new data (using ng-hide
+            // and ng-show).
+            //
+            // It's also possible there's a supported way to make this
+            // work. But nobody mentions it on the issue page.
+            //
+            $ionicHistory.currentView($ionicHistory.backView());
+
+            $state.go(state, {}, { location: 'replace' });
+        });
+    }
+
+    function compliant_yes() { make_report(true); }
+    function compliant_no() { make_report(false); }
+
+    Text.all_p()
+    .then(function(alltext) {
+        text = alltext;
+        $scope.text = alltext;
+        return Experiments.publish_p($scope);
+    })
+    .then(function(_) {
+        var cur = $scope.study_current;
+
+        if (!cur) {
+            // This should not be possible. If caller screwed up, the
+            // best we can do is probably go back to current trial.
+            //
+            $state.go('current');
+        }
+
+        // Caller assures us that we need to log a breakfast compliance.
+        // Find the first study day without a breakfast report.
+        //
+        logday = 1;
+        if (!Array.isArray(cur.reports))
+            cur.reports = [];
+        for (var i = 0; i < 10000; i++)
+            if (!Experiments.report_made(cur.reports[i], 'breakfast')) {
+                logday = i + 1;
+                break;
+            }
+
+        // Compute a name for the day to be logged.
+        //
+        var logday_name;
+        if (Experiments.study_day_today(cur) == logday) {
+            logday_name = text.during.today;
+        } else {
+            var ldd = new Date(cur.start_time * 1000);
+            ldd.setDate(ldd.getDate() + logday - 1);
+            logday_name = LC.datestr(ldd);
+        }
+        $scope.log_title = text.during.title.replace(/{DAY}/g, logday_name);
+
+        // Compute the phrase that says what they were supposed to do.
+        //
+        // XXX: need to choose between phrase_plus and phrase_minus
+        // depending on the randomized choice for the day.
+        //
+        var phrase = "?";
+        var trigger = cur.trigger.trim();
+        for (var i = 0; i < text.setup3.triggers.length; i++)
+            if (text.setup3.triggers[i].trigger == trigger) {
+                phrase = text.setup3.triggers[i].phrase_plus;
+                break;
+            }
+
+        $scope.log_subtitle = text.during.subtitle.replace(/{PHRASE}/g, phrase);
+    
+        // Functions for Yes / No buttons.
+        //
+        $scope.compliant_yes = compliant_yes;
+        $scope.compliant_no = compliant_no;
+    });
+})
+
+.controller('LogPostCtrl', function($scope, $state,
+                                    Reminders, Text, LC, Experiments) {
+    var text;
+    var logday; // What study day is being logged
+
+    function make_report(severity)
+    {
+        // XXX TEMP fix up later to handle multiple symptoms
+        var cur = $scope.study_current;
+
+        Experiments.get_report_p(cur.id, logday)
+        .then(function(report) {
+            if (!report) report = {}; // (Shouldn't happen, breakfast is first.)
+            report.study_day = logday;
+            report.symptom_scores = [
+                { name: cur.symptoms[0], score: Number(severity) }
+            ];
+            report.symptom_report_time = Math.floor(Date.now() / 1000);
+            return Experiments.put_report_p(cur.id, report);
+        })
+        .then(function(_) {
+            // Refetch current study with report.
+            //
+            return Experiments.get(cur.id);
+        })
+        .then(function(curex) {
+            // Sync the reminder state with new version of study.
+            //
+            var rd = curex.remdescrs;
+            var st = curex.start_time;
+            var et = curex.end_time;
+            var rt = Experiments.report_tally(curex);
+            return Reminders.sync(rd, st, et, rt);
+        })
+        .then(function(_) { $state.go('current'); });
+    }
+
+    function do_cancel()
+    {
+        $scope.log_model.severity = null;
+        $state.go('current');
+    }
+
+    function do_submit()
+    {
+        if ($scope.log_model.severity == null)
+            // (Not supposed to be possible.)
+            //
+            return;
+        make_report($scope.log_model.severity);
+    }
+
+    Text.all_p()
+    .then(function(alltext) {
+        text = alltext;
+        $scope.text = alltext;
+        return Experiments.publish_p($scope);
+    })
+    .then(function(_) {
+        var cur = $scope.study_current;
+
+        if (!cur) {
+            // This should not be possible. If caller screwed up, the
+            // best we can do is probably go back to current trial
+            // screen.
+            //
+            $state.go('current');
+        }
+
+        // Caller assures us that we need to log symptom severity. Find
+        // Find the first study day without a symptom report.
+        //
+        logday = 1;
+        if (!Array.isArray(cur.reports))
+            cur.reports = [];
+        for (var i = 0; i < 10000; i++)
+            if (!Experiments.report_made(cur.reports[i], 'symptomEntry')) {
+                logday = i + 1;
+                break;
+            }
+
+        // Compute a name for the day to be logged.
+        //
+        var logday_name;
+        if (Experiments.study_day_today(cur) == logday) {
+            logday_name = text.post.today;
+        } else {
+            var ldd = new Date(cur.start_time * 1000);
+            ldd.setDate(ldd.getDate() + logday - 1);
+            logday_name = LC.datestr(ldd);
+        }
+        $scope.log_title = text.post.title.replace(/{DAY}/g, logday_name);
+
+        $scope.log_subtitle = text.post.subtitle;
+
+        // Model for the severity; null => not selected yet.
+        //
+        $scope.log_model = { severity: null };
+
+        // Functions for Cancel / Submit buttons.
+        //
+        $scope.log_cancel = do_cancel;
+        $scope.log_submit = do_submit;
+    })
+})
+
+);

--- a/TummyTrials/www/json/setup.json
+++ b/TummyTrials/www/json/setup.json
@@ -23,8 +23,9 @@
 		"button": "Setup A New Study"
 	},
 	"during": {
-		"title": "No ongoing study",
-		"subtitle": "Did you eat at least 8 grams of lactose during your breakfast?",
+		"title": "Breakfast Compliance for {DAY}",
+		"subtitle": "Did you {PHRASE} during your breakfast?",
+                "today": "Today",
 		"button1": "Yes",
 		"button2": "No"
 	},
@@ -37,8 +38,9 @@
 		"text": "Remember, do not consume any food or beverage (other than water) for the next 3 hours. You will reminded to log your symptom severity level after 3 hours."
 	},
 	"post": {
-		"title": "No ongoing study",
-		"subtitle": "At its worse, how much has your symptom impacted your day since you last ate?",
+		"title": "Symptom Level for {DAY}",
+		"subtitle": "At its worst, how much has your symptom impacted your day since you last ate?",
+                "today": "Today",
 		"button1": "Submit",
 		"button2": "Cancel",
 		"likertlabels":[
@@ -189,10 +191,26 @@
 		"title": "2. Choose a Possible Cause",
 		"subtitle": "Which possible trigger do you want to test? ",
 		"triggers" : [
-			{"trigger": "Eating Large Meals ", "uisref": "setup_3_1"},
-			{"trigger": "Eating Lactose / Dairy ", "uisref": "setup_3_2"},
-			{"trigger": "Drinking Caffeine ", "uisref": "setup_3_3"},
-			{"trigger": "Eating Gluten ", "uisref": "setup_3_4"}		
+			{"trigger": "Eating Large Meals",
+                         "uisref": "setup_3_1",
+                         "phrase_plus": "eat a large meal",
+                         "phrase_minus": "avoid eating a large meal"
+                        },
+			{"trigger": "Eating Lactose / Dairy",
+                         "uisref": "setup_3_2",
+                         "phrase_plus": "eat at least 8 grams of lactose",
+                         "phrase_minus": "avoid eating any lactose"
+                        },
+			{"trigger": "Drinking Caffeine",
+                         "uisref": "setup_3_3",
+                         "phrase_plus": "drink caffeine",
+                         "phrase_minus": "avoid consuming any caffeine"
+                        },
+			{"trigger": "Eating Gluten",
+                         "uisref": "setup_3_4",
+                         "phrase_plus": "eat gluten",
+                         "phrase_minus": "avoid eating any gluten"
+                        }
 		],
 		"button": "Continue "
 	},

--- a/TummyTrials/www/templates/current.html
+++ b/TummyTrials/www/templates/current.html
@@ -1,4 +1,4 @@
-<ion-view title="Current Trial">
+<ion-view title="Current Trial" cache-view="false">
   <ion-pane>
     <ion-content>
     <div class="calendar">

--- a/TummyTrials/www/templates/currenttrial/during.html
+++ b/TummyTrials/www/templates/currenttrial/during.html
@@ -1,17 +1,17 @@
-<ion-view title="Current Trial">
+<ion-view title="Current Trial" cache-view="false">
   <ion-pane>
     <ion-content class="padding">
       	<br/>
-		<h4 class="title"></h4>
+		<h4 class="title">{{log_title}}</h4>
 		<br/>
-		<p>{{text.during.subtitle}}</p>
+		<p>{{log_subtitle}}</p>
 		<br/>
 
     <div class="button-bar">
-  		<a class="button button-block button-royal" ui-sref="neg_compliance">
+  		<a class="button button-block button-royal" ng-click="compliant_no()">
               {{text.during.button2}}
       </a> &nbsp;
-      <a class="button button-block button-royal" ui-sref="pos_compliance">
+      <a class="button button-block button-royal" ng-click="compliant_yes()">
               {{text.during.button1}}
       </a>
     </div>

--- a/TummyTrials/www/templates/currenttrial/post.html
+++ b/TummyTrials/www/templates/currenttrial/post.html
@@ -1,20 +1,20 @@
-<ion-view title="Current Trial">
+<ion-view title="Current Trial" cache-view="false">
   <ion-pane>
     <ion-content class="padding">
         <br/>
-    <h4 class="title"></h4>
+    <h4 class="title">{{log_title}}</h4>
     <br/>
-    <p>{{text.post.subtitle}}</p>
+    <p>{{log_subtitle}}</p>
     <br/>
     <div class="likert">
       
         <ul class="list">
           <li ng-repeat="label in text.post.likertlabels" class="item item-checkbox">
             <label class="checkbox">
-              <input type="radio" name="likert">
+              <input type="radio" name="likert" ng-value="$index" ng-model="log_model.severity">
             </label>
               {{label.label}}<br>
-              
+
             <span class="likertdetail">{{label.detail}}</span>
           </li>
         </ul>
@@ -22,10 +22,10 @@
     </div>
     <br>
     <div class="divcenter">
-      <a class="button button-royal" ui-sref="">
+      <a class="button button-royal" ng-click="log_cancel()">
         {{text.post.button2}}
       </a>      
-      <a class="button button-royal" ui-sref="">
+      <a class="button button-royal" ng-disabled="log_model.severity == null" ng-click="log_submit()">
         {{text.post.button1}}
       </a>
     </div>


### PR DESCRIPTION
The Breakfast Compliance and Symptom Level pages actually log to the DB. This in turn means that the badges on the app count down properly to 0 when logging is up to date.

Currently only the first symptom is logged, to avoid pushing too many changes at once.

The Breakfast Compliance page assumes for now that every day is a positive day (person should consume the food being tested). Need to fold in the A/B values for the days.