### PR TITLE
Accelerated demo of current trial

### DIFF
--- a/TummyTrials/www/index.html
+++ b/TummyTrials/www/index.html
@@ -23,6 +23,7 @@
     <!-- your app's js -->
     <script src="js/app.js"></script>
     <script src="js/controllers/lc.js"></script>
+    <script src="js/controllers/tdate.js"></script>
     <script src="js/controllers/lifecycle.js"></script>
     <script src="js/controllers/replicator.js"></script>
     <script src="js/controllers/couchdb.js"></script>
@@ -35,6 +36,7 @@
     <script src="js/controllers/loggingctrl.js"></script>
     <script src="js/controllers/mytrialsctrl.js"></script>
     <script src="js/controllers/pasttrial1ctrl.js"></script>
+    <script src="js/controllers/settingsctrl.js"></script>
     <script src="js/controllers/currentstudy.js"></script>
     <script src="js/controllers/setupdata.js"></script>
     <script src="js/controllers/symptomdata.js"></script>

--- a/TummyTrials/www/js/controllers/lc.js
+++ b/TummyTrials/www/js/controllers/lc.js
@@ -7,8 +7,8 @@
     .factory('LC', function() {
         return {
             datestr: function(d) {
-                // Return a string for the date. It looks like
-                // "Tue, Nov 3".
+                // Return a string for the date (or tdate). It looks
+                // like "Tue, Nov 3".
                 //
                 var days = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
                 var mons = ["Jan","Feb","Mar","Apr","May","Jun",

--- a/TummyTrials/www/js/controllers/loggingctrl.js
+++ b/TummyTrials/www/js/controllers/loggingctrl.js
@@ -4,11 +4,13 @@
 //
 
 (angular.module('tummytrials.loggingctrl',
-                [ 'tractdb.reminders', 'tummytrials.text', 'tummytrials.lc',
+                [ 'tractdb.tdate', 'tractdb.reminders',
+                  'tummytrials.text', 'tummytrials.lc',
                   'tummytrials.experiments', 'tummytrials.symptomdata' ])
 
 .controller('LogDuringCtrl', function($scope, $state, $ionicHistory,
-                                        Reminders, Text, LC, Experiments) {
+                                        TDate, Reminders, Text, LC,
+                                        Experiments) {
     var text;
     var logday; // What study day is being logged
 
@@ -21,7 +23,7 @@
             if (!report) report = {};
             report.study_day = logday;
             report.breakfast_compliance = compliant;
-            report.breakfast_report_time = Math.floor(Date.now() / 1000);
+            report.breakfast_report_time = Math.floor(TDate.now() / 1000);
             return Experiments.put_report_p(cur.id, report);
         })
         .then(function(_) {
@@ -102,7 +104,7 @@
         if (Experiments.study_day_today(cur) == logday) {
             logday_name = text.during.today;
         } else {
-            var ldd = new Date(cur.start_time * 1000);
+            var ldd = new TDate(cur.start_time * 1000);
             ldd.setDate(ldd.getDate() + logday - 1);
             logday_name = LC.datestr(ldd);
         }
@@ -131,12 +133,14 @@
 })
 
 .controller('LogPostCtrl', function($scope, $state, $stateParams,
-                            Reminders, Text, LC, Experiments, SymptomData) {
+                            TDate, Reminders, Text, LC, Experiments,
+                            SymptomData) {
     var text;
     var logday; // What study day is being logged
 
     function make_report_p(severity)
     {
+
         var cur = $scope.study_current;
 
         return Experiments.get_report_p(cur.id, logday)
@@ -151,7 +155,7 @@
                 scores.push(s);
             }
             report.symptom_scores = scores;
-            report.symptom_report_time = Math.floor(Date.now() / 1000);
+            report.symptom_report_time = Math.floor(TDate.now() / 1000);
             return Experiments.put_report_p(cur.id, report);
         })
         .then(function(_) {
@@ -262,7 +266,7 @@
         if (Experiments.study_day_today(cur) == logday) {
             logday_name = text.post.today;
         } else {
-            var ldd = new Date(cur.start_time * 1000);
+            var ldd = new TDate(cur.start_time * 1000);
             ldd.setDate(ldd.getDate() + logday - 1);
             logday_name = LC.datestr(ldd);
         }

--- a/TummyTrials/www/js/controllers/login.js
+++ b/TummyTrials/www/js/controllers/login.js
@@ -162,6 +162,13 @@
                 return askuser_p(0);
             },
 
+        loginfo_exists: function(storekey) {
+            // Return true iff there is login info stored under the
+            // given key.
+            //
+            return $window.localStorage.getItem(storekey) !== null;
+        },
+
         loginfo_clear: function(storekey) {
             // Clear any login info stored under the given key.
             //

--- a/TummyTrials/www/js/controllers/remind-test.js
+++ b/TummyTrials/www/js/controllers/remind-test.js
@@ -104,9 +104,17 @@
         return remind;
     }
 
-    function validate_reminds_equal(as, bs, tag)
+    function validate_reminds_equal(saw, exp, tag)
     {
-        if (!angular.equals(as, bs)) {
+        if (false) {
+            // (For debugging.)
+            //
+            console.log('validate_reminds_equal, saw',
+                        JSON.stringify(saw, null, 4));
+            console.log('validate_reminds_equal, expected',
+                        JSON.stringify(exp, null, 4));
+        }
+        if (!angular.equals(saw, exp)) {
             console.log('validate_reminds_equal<' + tag + '>: failure');
             throw new Error('validate_reminds_equal<' + tag + '>');
         }
@@ -136,8 +144,6 @@
             dos = 0;
         else
             dos = 1 + Math.trunc((moment - startt) / daysec);
-        if (dos > dayct)
-            return []; // Study is over
 
         // How many seconds past midnight is the moment?
         //
@@ -155,7 +161,7 @@
             if (dos <= 0)
                 n0 = 1; // Study hasn't started yet
             else
-                n0 = dos + (mtime < desc.time ? 0 : 1);
+                n0 = Math.min(dayct + 1, dos + (mtime < desc.time ? 0 : 1));
             // Previously issued reminders with no reports.
             //
             if (!desc.reminderonly)

--- a/TummyTrials/www/js/controllers/settingsctrl.js
+++ b/TummyTrials/www/js/controllers/settingsctrl.js
@@ -1,0 +1,78 @@
+// settingsctrl.js     Controller for Settings pane
+//
+
+(angular.module('tummytrials.settingsctrl',
+                [ 'tractdb.tdate', 'tractdb.reminders', 'tummytrials.text',
+                  'tummytrials.login', 'tummytrials.experiments' ])
+
+.controller('SettingsCtrl', function($scope, TDate, Reminders, Text, Login,
+                                     Experiments) {
+    var username_tag = 'couchuser'; // XXX shared with replicator.js
+
+    function clear_credentials()
+    {
+        Login.loginfo_clear(username_tag);
+        $scope.have_credentials = Login.loginfo_exists(username_tag);
+    }
+
+    function demo_is_possible()
+    {
+        // A demo is possible iff there is a current study that hasn't
+        // started yet, and there's no ongoing demo.
+        //
+        if (!$scope.study_current)
+            return false;
+        var tt = $scope.study_current.ttransform;
+        if (Object(tt) == tt)
+            return false; // There is ongoing demo
+        return Experiments.study_day_today($scope.study_current) < 1;
+    }
+
+    function begin_demo()
+    {
+        // Start the demo. For now, accelerate the study so it runs in
+        // an hour. Set the beginning of the study (midnight of first
+        // day) to right now.
+        //
+        var cur = $scope.study_current;
+
+        var speedup = (cur.end_time - cur.start_time) / (60 * 60);
+
+        // Algebra:
+        //
+        //     T(Date.now()) = starting_timestamp
+        //     T(Date.now()) = cur.start_time * 1000
+        //     speedup * Date.now() + offset = cur.start_time * 1000
+        //     offset = cur.start_time * 1000 - speedup * Date.now()
+
+        var offset = cur.start_time * 1000 - speedup * Date.now();
+
+        Experiments.set_ttransform_p(cur.id, speedup, offset)
+        .then(function(_) {
+            return Experiments.getCurrent();
+        })
+        .then(function(curex) {
+            $scope.study_current = curex;
+            $scope.demo_is_possible = demo_is_possible(); // Should be false
+            TDate.setTransform(speedup, offset);
+            var rd = curex.remdescrs;
+            var st = curex.start_time;
+            var et = curex.end_time;
+            var rt = Experiments.report_tally(curex);     // Should be {}
+            return Reminders.sync(rd, st, et, rt);
+        });
+    }
+
+    Text.all_p()
+    .then(function(text) {
+        $scope.text = text;
+        return Experiments.publish_p($scope);
+    })
+    .then(function(_) {
+        $scope.have_credentials = Login.loginfo_exists(username_tag);
+        $scope.clear_credentials = clear_credentials;
+        $scope.demo_is_possible = demo_is_possible();
+        $scope.begin_demo = begin_demo;
+    });
+})
+);

--- a/TummyTrials/www/js/controllers/setupctrl.js
+++ b/TummyTrials/www/js/controllers/setupctrl.js
@@ -21,7 +21,8 @@ function timesec_of_date(date)
 }
 
 (angular.module('tummytrials.setupctrl',
-                [ 'tractdb.reminders', 'tummytrials.lc', 'tummytrials.text',
+                [ 'tractdb.tdate', 'tractdb.reminders',
+                  'tummytrials.lc', 'tummytrials.text',
                   'tummytrials.setupdata', 'tummytrials.studyfmt',
                   'tummytrials.experiments', 'tummytrials.replicator' ])
 
@@ -80,7 +81,7 @@ function timesec_of_date(date)
     });
 })
 
-.controller('Setup5Ctrl', function($scope, $state, Reminders, LC, Text,
+.controller('Setup5Ctrl', function($scope, $state, TDate, Reminders, LC, Text,
                                     SetupData, StudyFmt, Experiments,
                                     Replicator) {
 

--- a/TummyTrials/www/js/controllers/tdate.js
+++ b/TummyTrials/www/js/controllers/tdate.js
@@ -1,0 +1,236 @@
+// tdate.js     TractDB Date with timeline transform
+//
+// TDate replaces JavaScript Date, adding the ability to set a linear
+// transform of the timeline. If the app uses TDate in place of Date
+// throughout, this allows running a trial at accelerated speed, for
+// testing and demonstration.
+//
+// The class TDate has all the usual class methods of Date, plus the
+// following:
+//
+//     setTransform(a, b)    Set transform to f(t) = a * t + b
+//
+// Note that, for simplicity, just one transformed timeline is
+// supported, shared by all instances of TDate.
+//
+// Instances of TDate are created as for Date, i.e., by new TDate(...)
+// Instances have all the usual methods of dates, plus the following:
+//
+//     inverse()             Return an inversely transformed Date instance
+//
+// All the usual methods deal in transformed times. Let T be the
+// transform (f(t) = a * t + b), and NOW be the usual timestamp of the
+// current moment. Then
+//
+//     new TDate() => a tdate representing T(NOW)
+//     TDate.now() => the timestap T(NOW)
+//     new TDate(x) => a tdate whose timestamp is x
+//     new TDate(y, m, d, h, m, s) => tdate representing the given moment
+//
+// In essence, TDate works exactly like Date except that the present
+// moment moves through time according to the transform. Another way to
+// look at this is that a TDate instance has a timestamp that is
+// transformed from the usual timestamp. Or conversely, the usual
+// timestamp of a TDate instance (its "real" time) is inversely
+// transformed from the TDate's timestamp. If the transform is (1, 0),
+// there is no difference at all. If the transform is (60, 0),
+// transformed times have been proceeding 60 times faster than usual
+// since the beginning of the epoch.
+//
+// The inverse() method is used by those parts of the system that need
+// to know the "real" time corresponding to a transformed time. (In the
+// current setup, just the lowest level of the Reminders module needs to
+// know this.)
+//
+
+'use strict';
+
+(angular.module('tractdb.tdate', [])
+
+.factory('TDate', function() {
+
+    // Coefficients of the transform.
+    //
+    var a = 1, b = 0;
+
+    // Transform and its inverse.
+    //
+    function T(t) { return Math.round(a * t + b); }
+    function Tinv(t) { return Math.round((t - b) / a); }
+
+    // Constructor.
+    //
+    function TDate()
+    {
+        // A TDate instance has a transformed date inside to which it
+        // delegates almost all methods. (It's actually not possible to
+        // create a JS-style "subclass" of Date.)
+        //
+
+        if (!(this instanceof TDate)) {
+            // Constructor called without "new". This returns a string
+            // representing the current moment.
+            //
+            return new Date(T(Date.now())).toString();
+        } else if (arguments.length == 0) {
+            // Zero-argument form denotes the current moment, which is
+            // transformed.
+            //
+            this.tdate = new Date(T(Date.now()));
+        } else {
+            // All other forms denote a specified moment, acting as
+            // usual.
+            //
+            // It's possible but extremely tricky to create a new Date
+            // object from an array of arguments. (I got basic plan here
+            // from the net.)
+            //
+            var args = Array.prototype.slice.call(arguments);
+            args.unshift(Date);
+            var dfact = Date.bind.apply(Date, args);
+            this.tdate = new dfact();
+        }
+    }
+
+    // Interesting methods.
+    //
+    // (The rest are just delegations to Date or this.tdate.)
+    //
+
+    TDate.now = function() {
+        return T(Date.now());
+    }
+
+    TDate.setTransform = function(newa, newb) {
+        a = newa;
+        b = newb;
+    }
+
+    TDate.prototype = {};
+
+    TDate.prototype.inverse = function() {
+        return new Date(Tinv(this.tdate.getTime()));
+    }
+
+    // Delegated class methods.
+    //
+
+    TDate.parse = function(s) {
+        return Date.parse(s);
+    }
+
+    TDate.UTC = function() {
+        return Date.UTC.apply(null, arguments);
+    }
+
+    // Delegated instance methods.
+    //
+
+    TDate.prototype.getDate = function() { return this.tdate.getDate(); }
+    TDate.prototype.getDay = function() { return this.tdate.getDay(); }
+    TDate.prototype.getFullYear = function() {
+        return this.tdate.getFullYear();
+    }
+    TDate.prototype.getHours = function() { return this.tdate.getHours(); }
+    TDate.prototype.getMilliseconds = function() {
+        return this.tdate.getMilliseconds();
+    }
+    TDate.prototype.getMinutes = function() { return this.tdate.getMinutes(); }
+    TDate.prototype.getMonth = function() { return this.tdate.getMonth(); }
+    TDate.prototype.getSeconds = function() { return this.tdate.getSeconds(); }
+    TDate.prototype.getTime = function() { return this.tdate.getTime(); }
+    TDate.prototype.getTimezoneOffset = function() {
+        return this.tdate.getTimezoneOffset();
+    }
+    TDate.prototype.getUTCDate = function() { return this.tdate.getUTCDate(); }
+    TDate.prototype.getUTCDay = function() { return this.tdate.getUTCDay(); }
+    TDate.prototype.getUTCFullYear = function() {
+        return this.tdate.getUTCFullYear();
+    }
+    TDate.prototype.getUTCHours = function() {
+        return this.tdate.getUTCHours();
+    }
+    TDate.prototype.getUTCMilliseconds = function() {
+        return this.tdate.getUTCMilliseconds();
+    }
+    TDate.prototype.getUTCMinutes = function() {
+        return this.tdate.getUTCMinutes();
+    }
+    TDate.prototype.getUTCMonth = function() {
+        return this.tdate.getUTCMonth();
+    }
+    TDate.prototype.getUTCSeconds = function() {
+        return this.tdate.getUTCSeconds();
+    }
+    TDate.prototype.getYear = function() { return this.tdate.getYear(); }
+
+    TDate.prototype.setDate = function(n) { return this.tdate.setDate(n); }
+    TDate.prototype.setFullYear = function(n) {
+        return this.tdate.setFullYear(n);
+    }
+    TDate.prototype.setHours = function(n) { return this.tdate.setHours(n); }
+    TDate.prototype.setMilliseconds = function(n) {
+        return this.tdate.setMilliseconds(n);
+    }
+    TDate.prototype.setMinutes = function(n) {
+        return this.tdate.setMinutes(n);
+    }
+    TDate.prototype.setMonth = function(n) { return this.tdate.setMonth(n); }
+    TDate.prototype.setSeconds = function(n) {
+        return this.tdate.setSeconds(n);
+    }
+    TDate.prototype.setTime = function(n) { return this.tdate.setTimeh(n); }
+    TDate.prototype.setUTCDate = function(n) {
+        return this.tdate.setUTCDate(n);
+    }
+    TDate.prototype.setUTCFullYear = function(n) {
+        return this.tdate.setUTCFullYear(n);
+    }
+    TDate.prototype.setUTCHours = function(n) {
+        return this.tdate.setUTCHours(n);
+    }
+    TDate.prototype.setUTCMilliseconds = function(n) {
+        return this.tdate.setUTCMilliseconds(n);
+    }
+    TDate.prototype.setUTCMinutes = function(n) {
+        return this.tdate.setUTCMinutes(n);
+    }
+    TDate.prototype.setUTCMonth = function(n) {
+        return this.tdate.setUTCMonth(n);
+    }
+    TDate.prototype.setUTCSeconds = function(n) {
+        return this.tdate.setUTCSeconds(n);
+    }
+    TDate.prototype.setYear = function(n) { return this.tdate.setYear(n); }
+
+    TDate.prototype.toDateString = function() {
+        return this.tdate.toDateString();
+    }
+    TDate.prototype.toISOString = function() {
+        return this.tdate.toISOString();
+    }
+    TDate.prototype.toJSON = function() { return this.tdate.toJSON(); }
+    TDate.prototype.toGMTString = function() {
+        return this.tdate.toGMTString();
+    }
+    TDate.prototype.toLocaleDateString = function() {
+        return this.tdate.toLocaleDateString();
+    }
+    TDate.prototype.toLocaleString = function() {
+        return this.tdate.toLocaleString();
+    }
+    TDate.prototype.toLocaleTimeString = function() {
+        return this.tdate.toLocaleTimeString();
+    }
+    TDate.prototype.toString = function() { return this.tdate.toString(); }
+    TDate.prototype.toTimeString = function() {
+        return this.tdate.toTimeString();
+    }
+    TDate.prototype.toUTCString = function() {
+        return this.tdate.toUTCString();
+    }
+    TDate.prototype.valueOf = function() { return this.tdate.valueOf(); }
+
+    return TDate;
+})
+);

--- a/TummyTrials/www/json/setup.json
+++ b/TummyTrials/www/json/setup.json
@@ -168,7 +168,10 @@
 		"para2" : "Avoid testing triggers that you are confident will make your symptoms worse. You may choose only one factor to test at a time."
  	},	
 	"settings": {
-		"title": "Settings"
+                "clear_creds": "Clear Credentials",
+                "clear_explanation": "This will clear your stored username and password. You'll be prompted to enter them again later.",
+                "accelerated_demo": "Begin Accelerated Trial Demo",
+                "demo_explanation": "This will begin an accelerated demo of the most recently created trial. This is for demonstration purposes only. Do not do this for a genuine trial!"
 	},
 	"setup": {
 		"title": "Setup a new study",

--- a/TummyTrials/www/templates/settings.html
+++ b/TummyTrials/www/templates/settings.html
@@ -1,11 +1,23 @@
-<ion-view title="Settings">
-	<ion-pane>
-		<ion-content class="ten-padding">
-			<p>{{text.settings.title}}</p>
-
-		  <button class="button button-large button-block button-assertive" ng-click="loginfo_clear()">
-			  Clear Credentials
-	      </button>
-		</ion-content>  
-	</ion-pane>
+<ion-view title="Settings" cache-view="false">
+  <ion-pane>
+    <ion-content class="ten-padding">
+        <br/>
+        <div class="card">
+          <div class="item item-text-wrap divcenter">
+          <button class="button button-assertive" ng-click="clear_credentials()" ng-disabled="!have_credentials">
+              {{text.settings.clear_creds}}
+          </button>
+          <p style="font-style: italic;">{{text.settings.clear_explanation}}</p>
+          </div>
+        </div>
+        <div class="card">
+          <div class="item item-text-wrap divcenter">
+          <button class="button button-assertive" ng-click="begin_demo()" ng-disabled="!demo_is_possible">
+              {{text.settings.accelerated_demo}}
+          </button>
+          <p style="font-style: italic;">{{text.settings.demo_explanation}}</p>
+          </div>
+        </div>
+    </ion-content>  
+  </ion-pane>
 </ion-view>


### PR DESCRIPTION
If you have a current trial that hasn't started yet, you can do an accelerated demo of the trial by touching the button on the Settings page. This converts the trial to an accelerated trial. There's no way to convert back at the moment.

The acceleration is such that the whole trial takes place in 60 minutes. The moment when you touch the button establishes a simulated time of midnight on the first day of the trial. Generally the first message comes out at the simulated time of 7:00 am, which is around 2 minutes later in real time. (So you need to be patient at the beginning.)