### PR TITLE
Calendar widget shows scores for all symptoms being reported

### DIFF
--- a/TummyTrials/www/css/style.css
+++ b/TummyTrials/www/css/style.css
@@ -42,3 +42,8 @@
 .new_line{
 	white-space: pre-wrap;
 }
+
+/*Default text size in list seems to be 16px compared to 14px of p tag*/
+.list_text{
+	font-size: 14px;
+}

--- a/TummyTrials/www/json/setup.json
+++ b/TummyTrials/www/json/setup.json
@@ -21,9 +21,9 @@
 	},
 	"calendar": {
 		"title": "Log entry for day:",
-		"field_1": "Condition for the day was:",
-		"field_2": "Compliance for the day was:",
-		"field_3": "Symptom severity rating for the day was:",
+		"field_1": "Prompt for the day was to:",
+		"field_2": "Compliance with the prompt was:",
+		"field_3": "Symptom level reported for the day was:",
 		"future": "There is no data available for this date.",
 		"today": "This is the ongoing day.",
 		"neg": "The compliance for this day was negative and therefore, there is no symptom score for this day.",

--- a/TummyTrials/www/templates/current.html
+++ b/TummyTrials/www/templates/current.html
@@ -50,7 +50,7 @@
             <p>{{text.current.subtitle}} <b>{{active_text}}</b> {{text.current.subtitle2}}</p>
             <p><a style="text-decoration: underline; color:royal" ng-click="help = help ? false : true">{{text.current.para1}}</a></p> 
             <div class="card" ng-show="help">
-               <div class="item item-text-wrap">
+               <div class="item item-text-wrap list_text">
                    <b>For breakfast:</b><br/>
                    <span class="new_line">{{active_bfst}}</span><br/><br/>
                    <b>For drink:</b><br/>

--- a/TummyTrials/www/templates/currenttrial/calendar.html
+++ b/TummyTrials/www/templates/currenttrial/calendar.html
@@ -6,9 +6,17 @@
         <div ng-if="cal_display === 'yes'" class="padding card">
         	<h4>{{text.calendar.title}} {{cal_day}}</h4>
         	<p> {{text.calendar.field_1}} <b>{{cal_cond}}</b></p>
-        	<p> {{text.calendar.field_2}} <b>{{cal_comp}}</b></p>
-        	<p> {{text.calendar.field_3}} <b>{{cal_scr_txt}}</b></p>
+        	<p> {{text.calendar.field_2}} <b>{{cal_comp}}</b></p>            
+            <p> {{text.calendar.field_3}} <br/><br/>
+            <ul class="list">
+                <li class="item item-text-wrap list_text" ng-repeat="(key,value) in cal_scr">
+                    <b>{{key}}</b><br/> {{value}} 
+                </li>
+            </ul>
         </div>
+
+
+
 
         <!-- Content to display on invalid days (days in the future) -->
         <div ng-if="cal_display === 'no'" class="padding card">
@@ -37,6 +45,7 @@
             <p> {{text.calendar.missing}}</p>
         </div>
         
+
     </ion-content>  
   </ion-pane>
 </ion-view>


### PR DESCRIPTION
Fixed the issue where calendar widget only displayed score of the first
symptom being logged. It now shows name and value of all symtoms.

Minor styling edits:
- Added css class for making list item text size the same as <p> text
size. (14px).