### PR TITLE
Track page-to-page navigation in activity log of DB

### DIFF
--- a/TummyTrials/www/index.html
+++ b/TummyTrials/www/index.html
@@ -27,10 +27,12 @@
     <script src="js/controllers/tdate.js"></script>
     <script src="js/controllers/abshuffle.js"></script>
     <script src="js/controllers/lifecycle.js"></script>
+    <script src="js/controllers/touchtrack.js"></script>
     <script src="js/controllers/replicator.js"></script>
     <script src="js/controllers/couchdb.js"></script>
     <script src="js/controllers/experiments.js"></script>
     <script src="js/controllers/activitylog.js"></script>
+    <script src="js/controllers/navlog.js"></script>
     <script src="js/controllers/reminders.js"></script>
     <script src="js/controllers/login.js"></script>
     <script src="js/controllers/text.js"></script>

--- a/TummyTrials/www/js/app.js
+++ b/TummyTrials/www/js/app.js
@@ -25,7 +25,9 @@ angular.module('starter', ['ionic'])
 
 var app = angular.module('tummytrials',
             ['ionic', 'ngSanitize', 'ngCordova',
-            'tractdb.tdate', 'tractdb.lifecycle', 'tummytrials.replicator',
+            'tractdb.tdate', 'tractdb.lifecycle',
+            'tractdb.touchtrack', 'tractdb.navlog',
+            'tummytrials.replicator',
             'tummytrials.login', 'tummytrials.currentstudy',
             'tummytrials.studysetup', 'tummytrials.faqcontroller',
             'tummytrials.activitylog', 'tummytrials.currentctrl',

--- a/TummyTrials/www/js/controllers/navlog.js
+++ b/TummyTrials/www/js/controllers/navlog.js
@@ -1,0 +1,68 @@
+// navlog.js     Log navigation from page to page
+//
+// This module subscribes to location change events, and logs them to
+// the DB. Currently there's no interface to this module, it's supposed
+// to "just work" all on its own.
+//
+
+'use strict';
+
+// NOTE: If parsing navigation particulars from the log messages is a
+// drag you could use special navigation records in the DB rather than
+// log entries.
+//
+
+var g_logger;
+
+(angular.module('tractdb.navlog',
+                [ 'tractdb.touchtrack', 'tummytrials.experiments' ])
+.run(function($ionicPlatform, $rootScope, $timeout, TouchTrack, Experiments) {
+    $ionicPlatform.ready(function() {
+
+        function log(s)
+        {
+            // Initiate an update to current study (if there is one).
+            // Note that we don't wait for the update to complete.
+            //
+            Experiments.getCurrent()
+            .then(function(curex) {
+                if (!curex)
+                    return null;
+                return Experiments.add_activity_p(curex.id, s);
+            });
+        }
+
+        function clear()
+        {
+            // (Ignore clear requests for now.)
+        }
+
+        g_logger = new Log4js.getLogger("Navigation");
+        g_logger.setLevel(Log4js.Level.ALL);
+        var app = new Log4js.AbstractAppender(log, clear);
+        var layo = new Log4js.BasicLayout();
+        layo.LINE_SEP = '';
+        app.setLayout(layo);
+        g_logger.addAppender(app);
+
+        $rootScope.$on('$locationChangeSuccess',
+            function(ev, newurl) {
+                // (It turns out that the location change is processed
+                // just *before* the button/link touch. So postpone
+                // location processing until the next event iteration to
+                // get proper association between touches and location
+                // changes.)
+                //
+                $timeout(function() {
+                    var s = '$locationChangeSuccess ' + newurl;
+                    var t = TouchTrack.latestNavTouch();
+                    if (t) {
+                        s = s + ' ' + t.attr + ' ' + t.nodeName;
+                        s = s + ' "' + t.textContent.replace(/"/g, '\\"') + '"';
+                    }
+                    g_logger.info(s);
+                }, 0);
+            });
+    });
+})
+);

--- a/TummyTrials/www/js/controllers/touchtrack.js
+++ b/TummyTrials/www/js/controllers/touchtrack.js
@@ -1,0 +1,101 @@
+// touchtrack.js     Track latest touches of links and buttons
+//
+
+'use strict';
+
+var g_history = new Array(10);
+var g_seen = 0;
+
+// Returned touch descriptions look like this:
+//
+// { time: time of touch (ms since Jan 1 1970 UTC).
+//   attr: attr associated with the navigation ('ng-click', 'ui-sref')
+//   nodeName: node name of associated element ('A', 'BUTTON', 'DIV')
+//   textContent: contained text ('Current Experiment', 'Back')
+// }
+//
+
+function saw_touch(el, attr)
+{
+    var info = { };
+    info.time = Date.now();
+    info.attr = attr;
+    info.nodeName = el[0].nodeName;
+    var text = el[0].textContent.trim().substring(0,32);
+    info.textContent = text;
+    g_history[g_seen++ % g_history.length] = info;
+}
+
+(angular.module('tractdb.touchtrack', [])
+.directive('ngClick', function() {
+    return {
+        restrict: 'A',
+        link: function(scope, el, attrs) {
+            el.bind('click', function(e) {
+                saw_touch(el, 'ng-click');
+            });
+        }
+    };
+})
+
+.directive('uiSref', function($timeout) {
+    return {
+        restrict: 'A',
+        link: function(scope, el, attrs) {
+            if (el[0].nodeName === 'ION-TAB') {
+                // Need to handle ION-TAB specially. The associated <a>
+                // elements are added as siblings, and are added after
+                // this postLink call. So schedule the handling for the
+                // next time around the event loop. You can definitely
+                // consider this a hack.
+                //
+                $timeout(function() {
+                    var el_index = -1;
+                    var sibs = el[0].parentNode.children;
+                    var seenct = 0;
+                    for (var i = 0; i < sibs.length; i++)
+                        if (sibs[i] === el[0]) {
+                            el_index = seenct;
+                            break;
+                        } else if(sibs[i].nodeName === 'ION-TAB') {
+                            seenct++;
+                        }
+                    if (el_index >= 0) {
+                        seenct = 0;
+                        for (var i = 0; i < sibs.length; i++)
+                            if (sibs[i].nodeName === 'A') {
+                                if (seenct == el_index) {
+                                    var ael = angular.element(sibs[i]);
+                                    ael.bind('click', function(e) {
+                                        saw_touch(ael, 'ui-sref');
+                                    });
+                                    break;
+                                } else {
+                                    seenct++;
+                                }
+                            }
+                    }
+                }, 0);
+            } else {
+                el.bind('click', function(e) {
+                    saw_touch(el, 'ui-sref');
+                });
+            }
+        }
+    };
+})
+
+.factory('TouchTrack', function() {
+    return {
+        latestNavTouch: function() {
+            // Return latest touch of a link or button, or null if there
+            // haven't been any yet.
+            //
+            if (g_seen < 1)
+                return null;
+            return g_history[(g_seen - 1) % g_history.length];
+        }
+    };
+})
+
+);


### PR DESCRIPTION
This code correlates page changes with the most recent touch of a link or button, then logs the new page (as a URL) and the button (identified by the text inside) into the activity log of the DB. Log entries use the category "Navigation". No changes are required anywhere else in the app, tracking is handled by augmenting Ionic navigation attributes and responding to navigation events.