### PR TITLE
Combine navigation and activity logging, improve

### DIFF
--- a/TummyTrials/www/index.html
+++ b/TummyTrials/www/index.html
@@ -32,7 +32,6 @@
     <script src="js/controllers/couchdb.js"></script>
     <script src="js/controllers/experiments.js"></script>
     <script src="js/controllers/activitylog.js"></script>
-    <script src="js/controllers/navlog.js"></script>
     <script src="js/controllers/reminders.js"></script>
     <script src="js/controllers/login.js"></script>
     <script src="js/controllers/text.js"></script>

--- a/TummyTrials/www/js/app.js
+++ b/TummyTrials/www/js/app.js
@@ -26,7 +26,7 @@ angular.module('starter', ['ionic'])
 var app = angular.module('tummytrials',
             ['ionic', 'ngSanitize', 'ngCordova',
             'tractdb.tdate', 'tractdb.lifecycle',
-            'tractdb.touchtrack', 'tractdb.navlog',
+            'tractdb.touchtrack',
             'tummytrials.replicator',
             'tummytrials.login', 'tummytrials.currentstudy',
             'tummytrials.studysetup', 'tummytrials.faqcontroller',
@@ -39,7 +39,7 @@ var app = angular.module('tummytrials',
 
 //Ionic device ready check
 app.run(function($cordovaFile, $ionicPlatform, $rootScope, $q,
-                    TDate, Login, Text, Experiments, ActivityLog,
+                    TDate, Login, Text, Experiments,
                     Reminders, ExperTest, RemindTest) {
 
   $ionicPlatform.ready(function() {
@@ -126,8 +126,10 @@ app.run(function($cordovaFile, $ionicPlatform, $rootScope, $q,
 
     // Log a user activity now and whenever the app resumes.
     //
-    ActivityLog.info('app startup');
-    $rootScope.$on('appResume', function() { ActivityLog.info('app resume'); });
+    // NO LONGER NEEDED: ActivityLog works autonomously.
+    //
+    // ActivityLog.info('app startup');
+    // $rootScope.$on('appResume', function() { ActivityLog.info('app resume'); });
 
     // Some tests of Experiments. Move these into some kind of framework
     // later on, probably. (Note: right now some of the tests fail if

--- a/TummyTrials/www/js/controllers/activitylog.js
+++ b/TummyTrials/www/js/controllers/activitylog.js
@@ -1,39 +1,130 @@
 // activitylog.js     Log for user activities
 //
-// User activities are logged to the current study in a field named
+// This module subscribes to events and logs them to the DB. Currently
+// there's no interface to this module, it's supposed to "just work" all
+// on its own. Events are logged to the current study in a field named
 // activity_log (an array of strings).
+//
+// Events are organized into log categories:
+//
+//     Activity: app startup, pause, resign, active, resume
+//     Navigation: user goes to new web page
+//
+// Navigation events are associated with specific button or link touches
+// using the TouchTrack module.
+//
+// For what it's worth, pause events don't seem dependable for writing
+// the DB. The docs say their code will be executed when the app is
+// resumed, but I don't see this all the time.  The iOS-specific resign
+// event seems to be more dependable (maybe because it happens a few
+// microseconds earlier).
 //
 
 'use strict';
 
+var g_actlogger; // Logger for Activity category
+var g_navlogger; // Logger for Navigation category
+
+
 (angular.module('tummytrials.activitylog', ['tummytrials.experiments'])
-    .factory('ActivityLog', function(Experiments) {
+.run(function($ionicPlatform, $rootScope, $timeout, $state, TouchTrack,
+                Experiments) {
 
-        function log(s)
-        {
-            // Initiate an update to current study (if there is one).
-            // Note that we don't wait for the update to complete.
+    function log(s)
+    {
+        // Log an event to current study (if there is one). Note that
+        // we don't wait for the update to complete.
+        //
+        Experiments.getCurrent()
+        .then(function(curex) {
+            if (!curex)
+                return null;
+
+            // Add millisec timestamp and current page URL to the
+            // message.
             //
-            Experiments.getCurrent()
-            .then(function(curex) {
-                if (!curex)
-                    return null;
-                return Experiments.add_activity_p(curex.id, s);
-            });
-        }
+            var infix = Date.now() + ' ' + $state.href($state.current);
+            var rb = s.indexOf(']');
+            var msg;
+            if (rb < 0) {
+                msg = infix + ' ' + s; // Not going to happen
+            } else {
+                msg = s.substr(0, rb + 1) + ' ' + infix + s.substr(rb + 1);
+            }
 
-        function clear()
-        {
-            // (Ignore clear requests for now.)
-        }
+            // Add to the study.
+            //
+            return Experiments.add_activity_p(curex.id, msg);
+        });
+    }
 
-        var logger = new Log4js.getLogger("Activity");
-        logger.setLevel(Log4js.Level.ALL);
-        var app = new Log4js.AbstractAppender(log, clear);
-        var layo = new Log4js.BasicLayout();
-        layo.LINE_SEP = '';
-        app.setLayout(layo);
-        logger.addAppender(app);
-        return logger;
-    })
+    function clear()
+    {
+        // (Ignore clear requests for now.)
+    }
+
+    $ionicPlatform.ready(function() {
+        g_actlogger = new Log4js.getLogger("Activity");
+        g_actlogger.setLevel(Log4js.Level.ALL);
+        var aapp = new Log4js.AbstractAppender(log, clear);
+        var alayo = new Log4js.BasicLayout();
+        alayo.LINE_SEP = '';
+        aapp.setLayout(alayo);
+        g_actlogger.addAppender(aapp);
+
+        g_navlogger = new Log4js.getLogger("Navigation");
+        g_navlogger.setLevel(Log4js.Level.ALL);
+        var napp = new Log4js.AbstractAppender(log, clear);
+        var nlayo = new Log4js.BasicLayout();
+        nlayo.LINE_SEP = '';
+        napp.setLayout(nlayo);
+        g_navlogger.addAppender(napp);
+
+        // There is an app startup right now.
+        //
+        g_actlogger.info('appStartup');
+
+        // Log other lifecycle events when they happen.
+        //
+        $rootScope.$on('appPause',
+            function(ev) { g_actlogger.info('appPause'); }
+        );
+
+        $rootScope.$on('appResign',
+            function(ev) { g_actlogger.info('appResign'); }
+        );
+
+        $rootScope.$on('appActive',
+            function(ev) { g_actlogger.info('appActive'); }
+        );
+
+        $rootScope.$on('appResume',
+            function(ev) { g_actlogger.info('appResume'); }
+        );
+
+        // Log navigation events.
+        //
+        $rootScope.$on('$locationChangeSuccess',
+            function(ev, newurl) {
+                // (It turns out that the location change is processed
+                // just *before* the button/link touch. So postpone
+                // location processing until the next event iteration to
+                // get proper association between touches and location
+                // changes.)
+                //
+                $timeout(function() {
+                    // Note: not using newurl for now.
+                    //
+                    var s = '$locationChangeSuccess';
+                    var t = TouchTrack.latestNavTouch();
+                    if (t) {
+                        s = s + ' ' + t.time + ' ' + t.attr + ' ' + t.nodeName;
+                        s = s + ' "' + t.textContent.replace(/"/g, '\\"') + '"';
+                    }
+                    g_navlogger.info(s);
+                }, 0);
+            }
+        );
+    });
+})
 );

--- a/TummyTrials/www/js/controllers/lifecycle.js
+++ b/TummyTrials/www/js/controllers/lifecycle.js
@@ -25,6 +25,16 @@
         $document[0].addEventListener("resume", function() {
             $rootScope.$broadcast('appResume');
         });
+
+        // These are iOS-specific events. They seem to be more reliable
+        // than the above, when writing to the DB.
+        //
+        $document[0].addEventListener("resign", function() {
+            $rootScope.$broadcast('appResign');
+        });
+        $document[0].addEventListener("active", function() {
+            $rootScope.$broadcast('appActive');
+        });
     });
 })
 );


### PR DESCRIPTION
Combined activity & navigation logging. Code in navlog.js is no longer used.

Log an activity when user leaves a page (by pressing home button or locking phone).

Add more precise timestamps to all log entries. Right now, they are JavaScript-style timestamps, ms since 1970. Also add URLs to all log entries, showing current page. (At startup this can be null.)

The activity logging code is autonomous, it does its thing without being called externally. So there are no entry points at the moment.
