### PR TITLE
Maintain history of breakfast and symptom reports

### DIFF
--- a/TummyTrials/www/js/controllers/currentctrl.js
+++ b/TummyTrials/www/js/controllers/currentctrl.js
@@ -100,39 +100,43 @@
             //
             var rinfo = [];
 
-            // If the user falls behind in reporting, there can be
-            // reports due for days in the past. Or there can be reports
-            // due now or sometime later today. We'll guide the user to
-            // make the earliest such report. So figure out its type.
-            //
-            var rep_type = null; // Next report to make; null => done thru today
-            var sdn = Math.min(Experiments.study_day_today(cur),
-                               Experiments.study_duration(cur));
+// We're going to require the user to enter the info for each day on the
+// day itself. So, no falling behind.
+//
+//
+//          // If the user falls behind in reporting, there can be
+//          // reports due for days in the past. Or there can be reports
+//          // due now or sometime later today. We'll guide the user to
+//          // make the earliest such report. So figure out its type.
+//          //
+//          var rep_type = null; // Next report to make; null => done thru today
+//          var sdn = Math.min(Experiments.study_day_today(cur),
+//                             Experiments.study_duration(cur));
 
-            found: for (var sd = 1; sd <= sdn; sd++) {
-                if (!cur.reports || !cur.reports[sd - 1]) {
-                    // No report object at all; so, first report of day
-                    // is earliest report due.
-                    //
-                    for (var i = 0; i < cur.remdescrs.length; i++) {
-                        if (!cur.remdescrs[i].reminderonly) {
-                            rep_type = cur.remdescrs[i].type;
-                            break found;
-                        }
-                    }
-                    break found; // (No reportable reminders at all?)
-                }
-                var rsd = cur.reports[sd - 1];
-                for (var i = 0; i < cur.remdescrs.length; i++) {
-                    if (cur.remdescrs[i].reminderonly)
-                        continue;
-                    var ty = cur.remdescrs[i].type;
-                    if (!Experiments.report_made(rsd, ty)) {
-                        rep_type = ty;
-                        break found;
-                    }
-                }
-            }
+//          found: for (var sd = 1; sd <= sdn; sd++) {
+//              if (!cur.reports || !cur.reports[sd - 1]) {
+//                  // No report object at all; so, first report of day
+//                  // is earliest report due.
+//                  //
+//                  for (var i = 0; i < cur.remdescrs.length; i++) {
+//                      if (!cur.remdescrs[i].reminderonly) {
+//                          rep_type = cur.remdescrs[i].type;
+//                          break found;
+//                      }
+//                  }
+//                  break found; // (No reportable reminders at all?)
+//              }
+//              var rsd = cur.reports[sd - 1];
+//              for (var i = 0; i < cur.remdescrs.length; i++) {
+//                  if (cur.remdescrs[i].reminderonly)
+//                      continue;
+//                  var ty = cur.remdescrs[i].type;
+//                  if (!Experiments.report_made(rsd, ty)) {
+//                      rep_type = ty;
+//                      break found;
+//                  }
+//              }
+//          }
 
             var rep_tally = Experiments.report_tally(cur);
 
@@ -141,7 +145,8 @@
                 info.reportdue =
                     !rd.reminderonly &&
                     rep_tally[rd.type] < Experiments.study_day_today(cur);
-                info.disabled = rd.type != rep_type;
+                // info.disabled = rd.type != rep_type;
+                info.disabled = false;
                 var msg, name;
                 msg = text.current.reminder_schedule_template;
                 name = text.current[rd.type + '_reminder_name'] || rd.type;

--- a/TummyTrials/www/js/controllers/loggingctrl.js
+++ b/TummyTrials/www/js/controllers/loggingctrl.js
@@ -86,17 +86,23 @@
             $state.go('current');
         }
 
-        // Caller assures us that we need to log a breakfast compliance.
-        // Find the first study day without a breakfast report.
-        //
-        logday = 1;
+// No need to figure out the day. All log entries are for today.
+//
+//      // Caller assures us that we need to log a breakfast compliance.
+//      // Find the first study day without a breakfast report.
+//      //
+//      logday = 1;
+//      if (!Array.isArray(cur.reports))
+//          cur.reports = [];
+//      for (var i = 0; i < 10000; i++)
+//          if (!Experiments.report_made(cur.reports[i], 'breakfast')) {
+//              logday = i + 1;
+//              break;
+//          }
+
         if (!Array.isArray(cur.reports))
             cur.reports = [];
-        for (var i = 0; i < 10000; i++)
-            if (!Experiments.report_made(cur.reports[i], 'breakfast')) {
-                logday = i + 1;
-                break;
-            }
+        logday = Experiments.study_day_today(cur);
 
         // Compute a name for the day to be logged.
         //
@@ -250,17 +256,21 @@
                 delete SymptomData.severity[cur.symptoms[symix]];
         });
 
-        // Caller assures us that we need to log symptom severity. Find
-        // the first study day without a symptom report.
-        //
-        logday = 1;
-        if (!Array.isArray(cur.reports))
-            cur.reports = [];
-        for (var i = 0; i < 10000; i++)
-            if (!Experiments.report_made(cur.reports[i], 'symptomEntry')) {
-                logday = i + 1;
-                break;
-            }
+//      // Caller assures us that we need to log symptom severity. Find
+//      // the first study day without a symptom report.
+//      //
+//      logday = 1;
+//      if (!Array.isArray(cur.reports))
+//          cur.reports = [];
+//      for (var i = 0; i < 10000; i++)
+//          if (!Experiments.report_made(cur.reports[i], 'symptomEntry')) {
+//              logday = i + 1;
+//              break;
+//          }
+
+// No need to figure out the day to log. All logging is for today.
+//
+        logday = Experiments.study_day_today(cur);
 
         // Compute a name for the day to be logged.
         //


### PR DESCRIPTION
The Experiments module now maintains a history of breakfast and symptom reports. Not a general history facility, just some code to save the old values in an array for each type of report. See the big comment at beginning of experiments.js.

I removed code that prevents multiple reports for the same day. I also removed the code that allows reporting for previous days. So all reports are for today. No doubt this code will need to be fixed up for the changes in the GUI.
