### PR TITLE
Prevent double touch of "begin study" button

### DIFF
--- a/TummyTrials/www/js/controllers/setupctrl.js
+++ b/TummyTrials/www/js/controllers/setupctrl.js
@@ -318,6 +318,7 @@ function timesec_of_date(date)
         //
         function begin_study()
         {
+            $scope.begin_study_called = true;
             create_study_p(text)
             .then(function(experid) {
                 return Experiments.get(experid);
@@ -340,6 +341,7 @@ function timesec_of_date(date)
             });
         }
         $scope.begin_study = begin_study;
+        $scope.begin_study_called = false;
 
         // Set some values in the scope for the template to use:
         //

--- a/TummyTrials/www/templates/study_setup/setup_5.html
+++ b/TummyTrials/www/templates/study_setup/setup_5.html
@@ -46,7 +46,7 @@
               Test3: {{drink_on_prompt}}<br/>
               Test4: {{drink_off_prompt}} -->
 
-              <a class="button button-block button-royal" ng-disabled="!study_data_complete" ng-click="begin_study()">
+              <a class="button button-block button-royal" ng-disabled="!study_data_complete || begin_study_called" ng-click="begin_study()">
                 {{text.setup5.button}}
               </a>
           </div>


### PR DESCRIPTION
Touching the "Begin Study" button disables the button, to avoid creating multiple experiments in DB. It seems to work great on my phone, but good to try on slower devices.